### PR TITLE
Add more models, fix column naming, add style guide, add SQLFluff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/sqlfluff/sqlfluff
+    rev: 3.0.7  # Use the latest version or specify a specific version
+    hooks:
+      - id: sqlfluff-lint
+        additional_dependencies: ['dbt-postgres', 'sqlfluff-templater-dbt']
+      - id: sqlfluff-fix
+        additional_dependencies: ['dbt-postgres', 'sqlfluff-templater-dbt']
+        args: [--config, '.sqlfluff']

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,35 @@
+[sqlfluff]
+templater = dbt
+dialect = postgres
+sql_file_exts = .sql,.sql.j2,.dml,.ddl
+exclude_rules = L031, L014, ST06
+large_file_skip_byte_limit = 0
+
+[sqlfluff:indentation]
+indent_unit = space
+indent_size = 4
+indented_joins = false
+indented_using_on = true
+template_blocks_indent = false
+
+[sqlfluff:templater]
+unwrap_wrapped_queries = true
+
+[sqlfluff:templater:jinja]
+apply_dbt_builtins = true
+load_macros_from_path = macros
+
+[sqlfluff:templater:dbt]
+project_dir = .
+profiles_dir = ~/.dbt
+; profile = <dbt profile>
+; target = <dbt target>
+
+[sqlfluff:rules:capitalisation.identifiers]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = upper
+
+[sqlfluff:layout:type:comma]
+line_position = leading

--- a/.sqlfluffignore
+++ b/.sqlfluffignore
@@ -1,0 +1,6 @@
+macros/
+target/
+dbt_packages/
+dbt-env/
+logs/
+seeds/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip3 install dbt-postgres==1.7.4
 ```
 
  5. Set up your [profiles.yml file](https://docs.getdbt.com/docs/core/connect-data-platform/profiles.yml):
-   - Run `touch ~/.dbt/profiles.yml` if you don't already have a profiles.yml file on your machine
+   - Create a directory `.dbt` in your root directory if one doesn't exist already, then create a `profiles.yml` file in `.dbt` 
    - Add the following block to the file:
 ```yaml
 synthea_omop_etl:

--- a/README.md
+++ b/README.md
@@ -69,3 +69,16 @@ dbt run
 ```bash
 dbt test
 ```
+
+ 11. Install SQLFluff:
+```bash
+pip3 install sqlfluff==3.0.7 sqlfluff-templater-dbt
+```
+  - Verify installation with `sqlfluff version`
+
+ 12. Install pre-commit:
+```bash
+pip3 install pre-commit==3.7.1
+pre-commit install
+```
+  - Verify functionality upon your first commit to the repo.  SQLFluff should run lint and fix on your files.  You must fix any unfixable violations manually before you'll be allowed to commit

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,131 @@
+# dbt-synthea Style Guide
+
+## Overview
+
+This style guide outlines the standards and best practices for organizing and writing SQL code within our dbt repository. Following these guidelines ensures consistency, readability, and maintainability of our codebase.  
+
+The style guide will evolve over time as we establish ways of working that best suit our team and project requirements.  Feel free to suggest changes in a PR or GitHub issue. 
+
+## Directory Structure
+
+### Directory Layout
+
+```plaintext
+dbt_project/
+├── macros/
+|   ├── _macros.yml
+│   ├── macro_1.sql
+├── models/
+│   ├── staging/
+│   │   ├── source_1/
+│   │   │   ├── _source_1__models.yml
+│   │   │   ├── _source_1__sources.yml
+│   │   │   ├── stg_source_1__table_1.sql
+│   │   |   ├── stg_source_1__table_2.sql
+│   ├── intermediate/
+│   │   ├── category_1/
+│   │   |   ├── _category_1__models.yml
+│   │   |   ├── int_category_1__table_1.sql
+│   │   |   ├── int_category_1__table_2.sql
+│   ├── marts/
+│   │   ├── mart_1/
+│   │   │   ├── _mart_1__models.yml
+│   │   │   ├── _mart_1__docs.md
+│   │   │   ├── model_1.sql
+│   │   │   ├── model_2.sql
+├── seeds/
+│   ├── source_1/
+│   |   ├── seed_data.csv
+├── tests/
+│   ├── test_1.sql
+```
+
+### Directory Definitions
+
+- **models**: Contains all model files.
+  - **staging**: Models for pulling raw data into the project and applying basic column cleaning rules (renaming, typecasting).
+  - **intermediate**: Intermediate transformation layers.
+  - **marts**: Business logic and final output models.
+- **seeds**: CSV files that are loaded into the data warehouse.
+- **macros**: Custom dbt macros.
+- **tests**: Custom test queries.
+
+## SQL Styling
+
+### General SQL Conventions
+
+1. **Uppercase SQL Keywords**:
+   - Always use all-caps for SQL keywords for better readability.
+   ```sql
+   SELECT
+       column_1
+   FROM table_name
+   WHERE
+       condition;
+   ```
+
+2. **Commas Preceding Each Column**:
+   - Place a comma at the beginning of each new line for columns in a SELECT statement.
+   ```sql
+   SELECT
+       column_1
+     , column_2
+     , column_3
+   FROM table_name;
+   ```
+
+3. **Indentation**:
+   - Use 4 spaces for indentation.
+   - Align SQL clauses for readability.
+   ```sql
+   SELECT
+       column_1
+     , column_2
+   FROM table_name
+   WHERE
+       condition_1
+       AND condition_2;
+   ```
+
+4. **Joins**:
+   - Align JOIN clauses for better readability.
+   ```sql
+   SELECT
+       a.column_1
+     , b.column_2
+   FROM table_a a
+   JOIN
+       table_b b
+       ON a.id = b.id;
+   ```
+### Jinja Syntax
+
+1. **Use Double Curly Braces**:
+   - Enclose Jinja expressions with double curly braces `{{ }}`.
+   - Pad Jinja expressions with one space on either side within the braces
+   ```sql
+   SELECT
+       {{ dbt_utils.current_timestamp() }}
+   ```
+
+## Repository Management
+
+### Version Control
+
+- Commit messages should be clear and descriptive.
+- Use feature branches for new development and bug fixes.  Give the branch a short, descriptive name prefixed with your name (e.g. `katy__add_person_mart`).
+
+### Documentation
+
+- Update yaml configs whenever you add or change a model.
+- Column descriptions only need to be added when the purpose of the column is not evident from its name.
+
+### Testing
+
+- Add tests where appropriate for all new columns and models.
+- Place custom tests in the `tests` directory.
+- Ensure `dbt run` completes successfully and that all tests pass before opening a pull request.
+
+## Other
+
+For anything not covered here, refer to the dbt best practices [guide](https://docs.getdbt.com/best-practices).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -54,6 +54,8 @@ dbt_project/
 
 ### General SQL Conventions
 
+Note that SQLFluff will enforce these conventions automatically if properly installed.  Pre-commit hooks will ensure all newly-committed SQL code is linted and compliant with conventions.
+
 1. **Uppercase SQL Keywords**:
    - Always use all-caps for SQL keywords for better readability.
    ```sql
@@ -87,17 +89,6 @@ dbt_project/
        AND condition_2;
    ```
 
-4. **Joins**:
-   - Align JOIN clauses for better readability.
-   ```sql
-   SELECT
-       a.column_1
-     , b.column_2
-   FROM table_a a
-   JOIN
-       table_b b
-       ON a.id = b.id;
-   ```
 ### Jinja Syntax
 
 1. **Use Double Curly Braces**:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -43,6 +43,7 @@ seeds:
           DIAGNOSIS6: varchar
           DIAGNOSIS7: varchar
           DIAGNOSIS8: varchar
+          REFERRINGPROVIDERID: varchar
       conditions:
         +column_types:
           CODE: varchar

--- a/macros/lowercase_columns.sql
+++ b/macros/lowercase_columns.sql
@@ -1,0 +1,6 @@
+{% macro lowercase_columns(column_names) %}
+    {% for column_name in column_names %} 
+        "{{ column_name }}" AS {{ column_name | lower }} 
+        {% if not loop.last %},{% endif %} 
+    {% endfor %}
+{% endmacro %}

--- a/models/marts/omop/person.sql
+++ b/models/marts/omop/person.sql
@@ -1,5 +1,4 @@
 SELECT
-
     {{ dbt_utils.generate_surrogate_key(['patient_id']) }} AS person_id
     , 0 AS gender_concept_id
     , DATE_PART('year', birth_date) AS year_of_birth
@@ -18,5 +17,4 @@ SELECT
     , 0 AS race_source_concept_id
     , ethnicity AS ethnicity_source_value
     , 0 AS ethnicity_source_concept_id
-
 FROM {{ ref('stg_synthea__patients') }}

--- a/models/marts/omop/person.sql
+++ b/models/marts/omop/person.sql
@@ -2,9 +2,9 @@ SELECT
 
     {{ dbt_utils.generate_surrogate_key(['patient_id']) }} AS person_id,
     0 AS gender_concept_id
-    , DATE_PART('year', patient_birth_date) AS year_of_birth
-    , DATE_PART('month', patient_birth_date) AS month_of_birth
-    , DATE_PART('day', patient_birth_date) AS day_of_birth
+    , DATE_PART('year', birth_date) AS year_of_birth
+    , DATE_PART('month', birth_date) AS month_of_birth
+    , DATE_PART('day', birth_date) AS day_of_birth
     , NULL AS birth_datetime
     , 0 AS race_concept_id
     , 0 AS ethnicity_concept_id
@@ -14,9 +14,9 @@ SELECT
     , patient_id AS person_source_value
     , NULL AS gender_source_value
     , 0 AS gender_source_concept_id
-    , patient_race AS race_source_value
+    , race AS race_source_value
     , 0 AS race_source_concept_id
-    , patient_ethnicity AS ethnicity_source_value
+    , ethnicity AS ethnicity_source_value
     , 0 AS ethnicity_source_concept_id
 
 FROM {{ ref('stg_synthea__patients') }}

--- a/models/marts/omop/person.sql
+++ b/models/marts/omop/person.sql
@@ -1,7 +1,7 @@
 SELECT
 
-    {{ dbt_utils.generate_surrogate_key(['patient_id']) }} AS person_id,
-    0 AS gender_concept_id
+    {{ dbt_utils.generate_surrogate_key(['patient_id']) }} AS person_id
+    , 0 AS gender_concept_id
     , DATE_PART('year', birth_date) AS year_of_birth
     , DATE_PART('month', birth_date) AS month_of_birth
     , DATE_PART('day', birth_date) AS day_of_birth

--- a/models/staging/synthea/_synthea__models.yml
+++ b/models/staging/synthea/_synthea__models.yml
@@ -6,15 +6,15 @@ models:
         data_type: text
         tests:
           - unique
-      - name: patient_birth_date
+      - name: birth_date
         data_type: date
-      - name: patient_death_date
+      - name: death_date
         data_type: date
-      - name: patient_ssn
+      - name: ssn
         data_type: text
-      - name: patient_drivers_license_number
+      - name: drivers_license_number
         data_type: text
-      - name: patient_passport_number
+      - name: passport_number
         data_type: text
       - name: patient_prefix
         data_type: text
@@ -28,19 +28,19 @@ models:
         description: "Name suffix, such as PhD, MD, JD, etc."
       - name: patient_maiden_name
         data_type: text
-      - name: patient_marital_status
+      - name: marital_status
         description: "Marital Status. M is married, S is single. Currently no support for divorce (D) or widowing (W)."
         data_type: text
-      - name: patient_race
+      - name: race
         description: "Text description of patient's primary race."
         data_type: text
-      - name: patient_ethnicity
+      - name: ethnicity
         description: "Text description of patient's primary ethnicity."
         data_type: text
       - name: patient_gender
         description: "Gender. M is male, F is female."
         data_type: text
-      - name: patient_birthplace
+      - name: birthplace
         description: "Name of the town where the patient was born."
         data_type: text
       - name: patient_address
@@ -58,10 +58,10 @@ models:
         data_type: double precision
       - name: patient_longitude
         data_type: double precision
-      - name: patient_healthcare_expenses
+      - name: healthcare_expenses
         description: "The total lifetime cost of healthcare to the patient (i.e. what the patient paid)."
         data_type: double precision
-      - name: patient_healthcare_coverage
+      - name: healthcare_coverage
         description: "The total lifetime cost of healthcare services that were covered by Payers (i.e. what the insurance company paid)."
         data_type: double precision
 
@@ -82,6 +82,10 @@ models:
               field: patient_id
       - name: encounter_id
         data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
       - name: allergy_code
         data_type: text
       - name: allergy_code_system
@@ -93,7 +97,7 @@ models:
         description: "Identify entry as an allergy or intolerance."
       - name: allergy_category
         data_type: text
-        description: "Identify the category as drug, medication, food, or environment."
+        description: "Identify the allergy category as drug, medication, food, or environment."
       - name: reaction1_code
         data_type: text
         description: "Optional SNOMED code of the patient's reaction."
@@ -112,3 +116,161 @@ models:
       - name: reaction2_severity
         data_type: text
         description: "Severity of the second reaction: MILD, MODERATE, or SEVERE."
+
+  - name: stg_synthea__careplans
+    description: Synthea careplans table
+    columns:
+      - name: careplan_id
+        data_type: text
+        tests:
+          - unique
+      - name: careplan_start_date
+        data_type: date
+        description: "The date the careplan was initiated."
+      - name: careplan_stop_date
+        data_type: date
+        description: "The date the careplan ended, if applicable."
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: encounter_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: careplan_code
+        data_type: text
+      - name: careplan_description
+        data_type: text
+      - name: careplan_reason_code
+        data_type: text
+        description: "Diagnosis code from SNOMED-CT that this care plan addresses."
+      - name: careplan_reason_description
+        data_type: text
+  
+  - name: stg_synthea__claims_transactions
+    description: Synthea claim transactions table
+    columns:
+      - name: claim_transaction_id
+        data_type: text
+        tests:
+          - unique
+      - name: claim_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__claims')
+              field: claim_id
+      - name: charge_id
+        data_type: double precision
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: transaction_type
+        data_type: text
+        description: "Type of claim transaction: charge, payment, adjustment, transferin, transferout."
+      - name: transaction_amount
+        data_type: double precision
+        description: "Dollar amount for a CHARGE or TRANSFERIN."
+      - name: transaction_method  
+        data_type: text
+        description: "Payment made by CASH, CHECK, ECHECK, COPAY, SYSTEM (adjustments without payment), or CC (credit card)."
+      - name: transaction_from_date
+        data_type: date
+        description: "Transaction start date."
+      - name: transaction_to_date
+        data_type: date
+        description: "Transaction end date."
+      - name: place_of_service
+        data_type: text
+        description: "Foreign key to the organization."
+        tests:
+          - relationships:
+              to: ref('stg_synthea__organizations')
+              field: organization_id
+      - name: procedure_code
+        data_type: text
+      - name: procedure_code_modifier1
+        data_type: text 
+      - name: procedure_code_modifier2  
+        data_type: text
+      - name: claim_diagnosis_ref1
+        data_type: double precision 
+        description: "Number indicating which diagnosis code from the claim applies to this transaction, 1-8 are valid options."
+      - name: claim_diagnosis_ref2
+        data_type: double precision
+        description: "Number indicating which diagnosis code from the claim applies to this transaction, 1-8 are valid options."
+      - name: claim_diagnosis_ref3
+        data_type: double precision
+        description: "Number indicating which diagnosis code from the claim applies to this transaction, 1-8 are valid options."
+      - name: claim_diagnosis_ref4
+        data_type: double precision
+        description: "Number indicating which diagnosis code from the claim applies to this transaction, 1-8 are valid options."
+      - name: service_units
+        data_type: double precision
+        description: "Number of units of the service."
+      - name: department_id
+        data_type: double precision
+      - name: transaction_notes
+        data_type: text
+      - name: per_unit_amount
+        data_type: double precision
+        description: "Cost per unit."
+      - name: transfer_out_id 
+        data_type: double precision
+        description: "If the transaction is a TRANSFERIN, the Charge ID of the corresponding TRANSFEROUT row."
+      - name: transfer_type
+        data_type: text
+        description: "1 if transferred to the primary insurance, 2 if transferred to the secondary insurance, or p if transferred to the patient."
+      - name: payments
+        data_type: double precision
+        description: "Dollar amount of a payment for a PAYMENT row."
+      - name: adjustments
+        data_type: double precision
+        description: "Dollar amount of an adjustment for an ADJUSTMENT row."
+      - name: transfers
+        data_type: double precision
+        description: "Dollar amount of a transfer for a TRANSFERIN or TRANSFEROUT row."
+      - name: outstanding
+        data_type: double precision
+        description: "Dollar amount left unpaid after this transaction was applied."
+      - name: encounter_id
+        data_type: text
+        description: "Foreign key to the encounter."
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: claim_transaction_line_note
+        data_type: text
+      - name: patient_insurance_id
+        data_type: text
+        description: "Foreign key to the Payer Transitions table member ID."
+        tests:
+          - relationships:
+              to: ref('stg_synthea__payer_transitions')
+              field: member_id
+      - name: fee_schedule_id
+        data_type: double precision
+        description: "Fixed to 1."
+      - name: provider_id
+        data_type: text
+        description: "Foreign key to the provider."
+        tests:
+          - relationships:
+              to: ref('stg_synthea__providers')
+              field: provider_id
+      - name: supervising_provider_id
+        data_type: text
+        description: "Foreign key to the supervising provider."
+        tests:
+          - relationships:
+              to: ref('stg_synthea__providers')
+              field: provider_id

--- a/models/staging/synthea/_synthea__models.yml
+++ b/models/staging/synthea/_synthea__models.yml
@@ -384,6 +384,30 @@ models:
         data_type: integer
         description: "Type of claim: 1 is professional, 2 is institutional."
   
+  - name: stg_synthea__conditions
+    description: Synthea conditions table
+    columns:
+      - name: condition_start_date
+        data_type: date
+      - name: condition_stop_date
+        data_type: date
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: encounter_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: condition_code
+        data_type: text
+      - name: condition_description
+        data_type: text
+  
   - name: stg_synthea__devices
     description: Synthea devices table
     columns:
@@ -461,12 +485,372 @@ models:
       - name: total_encounter_cost
         data_type: double precision
         description: "The total cost of the encounter, including all line items."
-      - name: payer_coverage
+      - name: encounter_payer_coverage
         data_type: double precision
         description: "The amount of cost covered by the payer."
-      - name: reason_code
+      - name: encounter_reason_code
         data_type: text
         description: "Diagnosis code from SNOMED-CT, only if this encounter targeted a specific condition."
-      - name: reason_description
+      - name: encounter_reason_description
         data_type: text
+  
+  - name: stg_synthea__imaging_studies
+    description: Synthea imaging studies table
+    columns:
+      - name: imaging_id
+        data_type: text
+        tests:
+          - unique
+      - name: imaging_datetime
+        data_type: datetime
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: encounter_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: series_uid
+        data_type: text
+      - name: bodysite_code
+        data_type: text
+      - name: bodysite_description
+        data_type: text
+      - name: modality_code
+        data_type: text
+        description: "A DICOM-DCM code describing the method used to take the images."
+      - name: modality_description
+        data_type: text
+      - name: instance_uid
+        data_type: text
+      - name: sop_code
+        data_type: text
+        description: "A DICOM-SOP code describing the Subject-Object Pair (SOP) that constitutes the image."
+      - name: sop_description
+        data_type: text
+      - name: imaging_procedure_code
+        data_type: text
+
+  - name: stg_synthea__immunizations
+    description: Synthea immunizations table
+    columns:
+      - name: immunization_date
+        data_type: date
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: encounter_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: immunization_code
+        data_type: text
+      - name: immunization_description
+        data_type: text
+      - name: immunization_base_cost
+        data_type: double precision
+        description: "The line item cost of the immunization."
+  
+  - name: stg_synthea__medications
+    description: Synthea medications table
+    columns:
+      - name: medication_start_datetime
+        data_type: datetime
+      - name: medication_stop_datetime
+        data_type: datetime
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: payer_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__payers')
+              field: payer_id
+      - name: encounter_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: medication_code
+        data_type: text
+      - name: medication_description
+        data_type: text
+      - name: medication_base_cost
+        data_type: double precision
+        description: "The line item cost of the medication."
+      - name: medication_payer_coverage
+        data_type: double precision
+        description: "The amount of cost covered by the payer."
+      - name: dispenses
+        data_type: integer
+        description: "The number of times the prescription was filled."
+      - name: medication_total_cost
+        data_type: double precision
+        description: "The total cost of the prescription, including all dispenses."
+      - name: medication_reason_code
+        data_type: text
+        description: "Diagnosis code from SNOMED-CT specifying why this medication was prescribed."
+      - name: medication_reason_description
+        data_type: text
+  
+  - name: stg_synthea__observations
+    description: Synthea observations table
+    columns:
+      - name: observation_datetime
+        data_type: datetime
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: encounter_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: observation_category
+        data_type: text
+      - name: observation_code
+        data_type: text
+      - name: observation_description
+        data_type: text
+      - name: observation_value
+        data_type: text
+      - name: observation_units
+        data_type: text
+      - name: observation_value_type
+        data_type: text
+        description: "The datatype of Value: text or numeric."
+
+  - name: stg_synthea__organizations
+    description: Synthea organizations table
+    columns:
+      - name: organization_id
+        data_type: text
+        tests:
+          - unique
+      - name: organization_name
+        data_type: text
+      - name: organization_address
+        data_type: text
+      - name: organization_city
+        data_type: text
+      - name: organization_state
+        data_type: text
+      - name: organization_zip
+        data_type: text
+      - name: organization_latitude
+        data_type: double precision
+      - name: organization_longitude
+        data_type: double precision
+      - name: organization_phone
+        data_type: text
+      - name: organization_revenue
+        data_type: double precision
+        description: "The monetary revenue of the organization during the entire simulation."
+      - name: organization_utilization
+        data_type: integer
+        description: "The number of Encounters performed by this Organization."
+
+  - name: stg_synthea__payer_transitions
+    description: Synthea payer transitions table
+    columns:
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: member_id
+        data_type: text
+      - name: coverage_start_year
+        data_type: integer
+      - name: coverage_end_year
+        data_type: integer
+      - name: payer_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__payers')
+              field: payer_id
+      - name: secondary_payer_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__payers')
+              field: payer_id
+      - name: plan_owner_relationship
+        data_type: text
+        description: "The owner of the insurance policy. Legal values: Guardian, Self, Spouse."
+      - name: plan_owner_name
+        data_type: text
+        description: "The name of the insurance policy owner."
+
+  - name: stg_synthea__payers
+    description: Synthea payers table
+    columns:
+      - name: payer_id
+        data_type: text
+        tests:
+          - unique
+      - name: payer_name
+        data_type: text
+      - name: payer_city
+        data_type: text
+      - name: payer_state_headquartered
+        data_type: text
+      - name: payer_zip
+        data_type: text
+      - name: payer_phone
+        data_type: text
+      - name: payer_amount_covered
+        data_type: double precision
+        description: "The monetary amount paid to Organizations during the entire simulation."
+      - name: payer_amount_uncovered
+        data_type: double precision
+        description: "The monetary amount not paid to Organizations during the entire simulation, and covered out of pocket by patients."
+      - name: payer_revenue
+        data_type: double precision
+        description: "The monetary revenue of the payer during the entire simulation."
+      - name: covered_encounters
+        data_type: integer
+        description: "The number of Encounters paid for by this Payer."
+      - name: uncovered_encounters
+        data_type: integer
+        description: "The number of Encounters not paid for by this Payer, and paid out of pocket by patients."
+      - name: covered_medications
+        data_type: integer
+        description: "The number of Medications paid for by this Payer."
+      - name: uncovered_medications
+        data_type: integer
+        description: "The number of Medications not paid for by this Payer, and paid out of pocket by patients."
+      - name: covered_procedures
+        data_type: integer
+        description: "The number of Procedures paid for by this Payer."
+      - name: uncovered_procedures
+        data_type: integer
+        description: "The number of Procedures not paid for by this Payer, and paid out of pocket by patients."
+      - name: covered_immunizations
+        data_type: integer
+        description: "The number of Immunizations paid for by this Payer."
+      - name: uncovered_immunizations
+        data_type: integer
+        description: "The number of Immunizations not paid for by this Payer, and paid out of pocket by patients."
+      - name: unique_customers
+        data_type: integer
+        description: "The number of unique patients enrolled with this Payer during the entire simulation."
+      - name: avg_qols
+        data_type: double precision
+        description: "The average Quality of Life Scores (QOLS) for all patients enrolled with this Payer during the entire simulation."
+      - name: member_months
+        data_type: integer
+        description: "The total number of months that patients were enrolled with this Payer during the simulation and paid monthly premiums (if any)."
+      
+  - name: stg_synthea__procedures
+    description: Synthea procedures table
+    columns:
+      - name: procedure_start_datetime
+        data_type: datetime
+      - name: procedure_stop_datetime
+        data_type: datetime
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: encounter_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: procedure_code
+        data_type: text
+      - name: procedure_description
+        data_type: text
+      - name: procedure_base_cost
+        data_type: double precision
+        description: "The line item cost of the procedure."
+      - name: procedure_reason_code
+        data_type: text
+        description: "Diagnosis code from SNOMED-CT specifying why this procedure was performed."
+      - name: procedure_reason_description
+        data_type: text
+
+  - name: stg_synthea__providers
+    description: Synthea providers table
+    columns:
+      - name: provider_id
+        data_type: text
+        tests:
+          - unique
+      - name: organization_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__organizations')
+              field: organization_id
+      - name: provider_name
+        data_type: text
+      - name: provider_gender
+        data_type: text
+      - name: provider_specialty
+        data_type: text
+      - name: provider_address
+        data_type: text
+      - name: provider_city
+        data_type: text
+      - name: provider_state
+        data_type: text
+      - name: provider_zip
+        data_type: text
+      - name: provider_latitude
+        data_type: double precision
+      - name: provider_longitude
+        data_type: double precision
+      - name: provider_utilization
+        data_type: integer
+        description: "The number of Encounters performed by this Provider."
+  
+  - name: stg_synthea__supplies
+    description: Synthea supplies table
+    columns:
+      - name: supply_date
+        data_type: date
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: encounter_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: supply_code
+        data_type: text
+      - name: supply_description
+        data_type: text
+      - name: supply_quantity
+        data_type: integer
       

--- a/models/staging/synthea/_synthea__models.yml
+++ b/models/staging/synthea/_synthea__models.yml
@@ -383,5 +383,90 @@ models:
       - name: claim_type_id_2
         data_type: integer
         description: "Type of claim: 1 is professional, 2 is institutional."
-      
+  
+  - name: stg_synthea__devices
+    description: Synthea devices table
+    columns:
+      - name: device_start_date
+        data_type: datetime
+        description: "The date and time the device was associated to the patient."
+      - name: device_stop_datetime
+        data_type: datetime
+        description: "The date and time the device was removed, if applicable."
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: encounter_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: device_code
+        data_type: text
+      - name: device_description
+        data_type: text
+      - name: udi
+        data_type: text
+        description: "Unique Device Identifier."
+
+  - name: stg_synthea__encounters
+    description: Synthea encounters table
+    columns:
+      - name: encounter_id
+        data_type: text
+        tests:
+          - unique
+      - name: encounter_start_datetime
+        data_type: datetime
+      - name: encounter_stop_datetime
+        data_type: datetime
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: organization_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__organizations')
+              field: organization_id
+      - name: provider_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__providers')
+              field: provider_id
+      - name: payer_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__payers')
+              field: payer_id
+      - name: encounter_class
+        data_type: text
+        description: "The class of the encounter, such as ambulatory, emergency, inpatient, wellness, or urgentcare."
+      - name: encounter_code
+        data_type: text
+      - name: encounter_description
+        data_type: text
+      - name: base_encounter_cost
+        data_type: double precision
+        description: "The base cost of the encounter, not including any line item costs related to medications, immunizations, procedures, or other services."
+      - name: total_encounter_cost
+        data_type: double precision
+        description: "The total cost of the encounter, including all line items."
+      - name: payer_coverage
+        data_type: double precision
+        description: "The amount of cost covered by the payer."
+      - name: reason_code
+        data_type: text
+        description: "Diagnosis code from SNOMED-CT, only if this encounter targeted a specific condition."
+      - name: reason_description
+        data_type: text
       

--- a/models/staging/synthea/_synthea__models.yml
+++ b/models/staging/synthea/_synthea__models.yml
@@ -98,22 +98,22 @@ models:
       - name: allergy_category
         data_type: text
         description: "Identify the allergy category as drug, medication, food, or environment."
-      - name: reaction1_code
+      - name: reaction_1_code
         data_type: text
         description: "Optional SNOMED code of the patient's reaction."
-      - name: reaction1_description
+      - name: reaction_1_description
         data_type: text
         description: "Optional description of the Reaction1 SNOMED code."
-      - name: reaction1_severity
+      - name: reaction_1_severity
         data_type: text
         description: "Severity of the reaction: MILD, MODERATE, or SEVERE."
-      - name: reaction2_code
+      - name: reaction_2_code
         data_type: text
         description: "Optional SNOMED code of the patient's second reaction."
-      - name: reaction2_description
+      - name: reaction_2_description
         data_type: text
         description: "Optional description of the Reaction2 SNOMED code."
-      - name: reaction2_severity
+      - name: reaction_2_severity
         data_type: text
         description: "Severity of the second reaction: MILD, MODERATE, or SEVERE."
 
@@ -197,20 +197,20 @@ models:
               field: organization_id
       - name: procedure_code
         data_type: text
-      - name: procedure_code_modifier1
+      - name: procedure_code_modifier_1
         data_type: text 
-      - name: procedure_code_modifier2  
+      - name: procedure_code_modifier_2  
         data_type: text
-      - name: claim_diagnosis_ref1
+      - name: claim_diagnosis_ref_1
         data_type: double precision 
         description: "Number indicating which diagnosis code from the claim applies to this transaction, 1-8 are valid options."
-      - name: claim_diagnosis_ref2
+      - name: claim_diagnosis_ref_2
         data_type: double precision
         description: "Number indicating which diagnosis code from the claim applies to this transaction, 1-8 are valid options."
-      - name: claim_diagnosis_ref3
+      - name: claim_diagnosis_ref_3
         data_type: double precision
         description: "Number indicating which diagnosis code from the claim applies to this transaction, 1-8 are valid options."
-      - name: claim_diagnosis_ref4
+      - name: claim_diagnosis_ref_4
         data_type: double precision
         description: "Number indicating which diagnosis code from the claim applies to this transaction, 1-8 are valid options."
       - name: service_units
@@ -274,3 +274,114 @@ models:
           - relationships:
               to: ref('stg_synthea__providers')
               field: provider_id
+
+  - name: stg_synthea__claims
+    description: Synthea claims table
+    columns:
+      - name: claim_id
+        data_type: text
+        tests:
+          - unique
+      - name: patient_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__patients')
+              field: patient_id
+      - name: provider_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__providers')
+              field: provider_id
+      - name: primary_patient_insurance_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__payers')
+              field: payer_id
+      - name: secondary_patient_insurance_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__payers')
+              field: payer_id
+      - name: department_id
+        data_type: integer
+      - name: patient_department_id
+        data_type: integer
+      - name: diagnosis_1
+        data_type: text
+      - name: diagnosis_2
+        data_type: text
+      - name: diagnosis_3
+        data_type: text
+      - name: diagnosis_4
+        data_type: text
+      - name: diagnosis_5
+        data_type: text
+      - name: diagnosis_6
+        data_type: text
+      - name: diagnosis_7
+        data_type: text
+      - name: diagnosis_8
+        data_type: text
+      - name: referring_provider_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__providers')
+              field: provider_id
+      - name: encounter_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__encounters')
+              field: encounter_id
+      - name: current_ilness_date
+        data_type: date
+        description: "The date the patient experienced symptoms."
+      - name: service_date
+        data_type: date
+        description: "The date of the services on the claim."
+      - name: supervising_provider_id
+        data_type: text
+        tests:
+          - relationships:
+              to: ref('stg_synthea__providers')
+              field: provider_id
+      - name: claim_status_1
+        data_type: text
+        description: "Status of the claim from the Primary Insurance. BILLED or CLOSED."
+      - name: claim_status_2
+        data_type: text
+        description: "Status of the claim from the Secondary Insurance. BILLED or CLOSED."
+      - name: claim_status_patient
+        data_type: text
+        description: "Status of the claim from the Patient. BILLED or CLOSED."
+      - name: outstanding_1
+        data_type: double precision
+        description: "Total amount of money owed by Primary Insurance."
+      - name: outstanding_2
+        data_type: double precision
+        description: "Total amount of money owed by Secondary Insurance."
+      - name: outstanding_patient
+        data_type: double precision
+        description: "Total amount of money owed by Patient."
+      - name: last_billed_date_1
+        data_type: date
+        description: "Date the claim was sent to Primary Insurance."
+      - name: last_billed_date_2
+        data_type: date
+        description: "Date the claim was sent to Secondary Insurance."
+      - name: last_billed_date_patient
+        data_type: date
+        description: "Date the claim was sent to Patient."
+      - name: claim_type_id_1
+        data_type: integer
+        description: "Type of claim: 1 is professional, 2 is institutional."
+      - name: claim_type_id_2
+        data_type: integer
+        description: "Type of claim: 1 is professional, 2 is institutional."
+      
+      

--- a/models/staging/synthea/stg_synthea__allergies.sql
+++ b/models/staging/synthea/stg_synthea__allergies.sql
@@ -1,4 +1,3 @@
--- Returns a list of the columns from a relation, so you can then iterate in a for loop
 {% set column_names = 
     dbt_utils.get_filtered_columns_in_relation( source('synthea', 'allergies') ) 
 %}
@@ -6,27 +5,27 @@
 
 WITH cte_allergies_lower AS (
 
-    SELECT  
+    SELECT
 
-        {% for column_name in column_names %}
-            "{{ column_name }}" as {{ column_name | lower }}
-        {% if not loop.last %},{% endif %}
-        {% endfor %}
-        
+    {% for column_name in column_names %} -- noqa:disable=LT02
+        "{{ column_name }}" AS {{ column_name | lower }} -- noqa:disable=LT02
+        {% if not loop.last %},{% endif %} -- noqa:disable=LT02
+    {% endfor %} -- noqa:disable=LT02
+
     FROM {{ source('synthea','allergies') }}
-) 
+)
 
 , cte_allergies_rename AS (
 
-    SELECT 
-        start AS allergy_start_date
-        , stop AS allergy_stop_date
+    SELECT
+        "start" AS allergy_start_date
+        , "stop" AS allergy_stop_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS allergy_code
-        , system AS allergy_code_system
-        , description AS allergy_description
-        , type AS allergy_type
+        , "system" AS allergy_code_system
+        , "description" AS allergy_description
+        , "type" AS allergy_type
         , category AS allergy_category
         , reaction1 AS reaction1_code
         , description1 AS reaction1_description
@@ -38,5 +37,5 @@ WITH cte_allergies_lower AS (
 
 )
 
-SELECT  * 
+SELECT *
 FROM cte_allergies_rename

--- a/models/staging/synthea/stg_synthea__allergies.sql
+++ b/models/staging/synthea/stg_synthea__allergies.sql
@@ -22,12 +22,12 @@ WITH cte_allergies_lower AS (
         , "description" AS allergy_description
         , "type" AS allergy_type
         , category AS allergy_category
-        , reaction1 AS reaction1_code
-        , description1 AS reaction1_description
-        , severity1 AS reaction1_severity
-        , reaction2 AS reaction2_code
-        , description2 AS reaction2_description
-        , severity2 AS reaction2_severity
+        , reaction1 AS reaction_1_code
+        , description1 AS reaction_1_description
+        , severity1 AS reaction_1_severity
+        , reaction2 AS reaction_2_code
+        , description2 AS reaction_2_description
+        , severity2 AS reaction_2_severity
     FROM cte_allergies_lower
 
 )

--- a/models/staging/synthea/stg_synthea__allergies.sql
+++ b/models/staging/synthea/stg_synthea__allergies.sql
@@ -6,12 +6,7 @@
 WITH cte_allergies_lower AS (
 
     SELECT
-
-    {% for column_name in column_names %} -- noqa:disable=LT02
-        "{{ column_name }}" AS {{ column_name | lower }} -- noqa:disable=LT02
-        {% if not loop.last %},{% endif %} -- noqa:disable=LT02
-    {% endfor %} -- noqa:disable=LT02
-
+        {{ lowercase_columns(column_names) }}
     FROM {{ source('synthea','allergies') }}
 )
 

--- a/models/staging/synthea/stg_synthea__careplans.sql
+++ b/models/staging/synthea/stg_synthea__careplans.sql
@@ -1,4 +1,3 @@
--- Returns a list of the columns from a relation, so you can then iterate in a for loop
 {% set column_names = 
     dbt_utils.get_filtered_columns_in_relation( source('synthea', 'careplans') ) 
 %}
@@ -6,31 +5,31 @@
 
 WITH cte_careplans_lower AS (
 
-    SELECT  
+    SELECT
 
-        {% for column_name in column_names %}
-            "{{ column_name }}" as {{ column_name | lower }}
-        {% if not loop.last %},{% endif %}
-        {% endfor %}
-        
+    {% for column_name in column_names %} -- noqa:disable=LT02
+        "{{ column_name }}" AS {{ column_name | lower }} -- noqa:disable=LT02
+        {% if not loop.last %},{% endif %} -- noqa:disable=LT02
+    {% endfor %} -- noqa:disable=LT02
+
     FROM {{ source('synthea','careplans') }}
-) 
+)
 
 , cte_careplans_rename AS (
 
-    SELECT 
+    SELECT
         id AS careplan_id
-        , start AS careplan_start_date
-        , stop AS careplan_stop_date
+        , "start" AS careplan_start_date
+        , "stop" AS careplan_stop_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS careplan_code
-        , description AS careplan_description
+        , "description" AS careplan_description
         , reasoncode AS careplan_reason_code
         , reasondescription AS careplan_reason_description
     FROM cte_careplans_lower
 
 )
 
-SELECT  * 
+SELECT *
 FROM cte_careplans_rename

--- a/models/staging/synthea/stg_synthea__careplans.sql
+++ b/models/staging/synthea/stg_synthea__careplans.sql
@@ -6,12 +6,7 @@
 WITH cte_careplans_lower AS (
 
     SELECT
-
-    {% for column_name in column_names %} -- noqa:disable=LT02
-        "{{ column_name }}" AS {{ column_name | lower }} -- noqa:disable=LT02
-        {% if not loop.last %},{% endif %} -- noqa:disable=LT02
-    {% endfor %} -- noqa:disable=LT02
-
+        {{ lowercase_columns(column_names) }}
     FROM {{ source('synthea','careplans') }}
 )
 

--- a/models/staging/synthea/stg_synthea__careplans.sql
+++ b/models/staging/synthea/stg_synthea__careplans.sql
@@ -1,0 +1,36 @@
+-- Returns a list of the columns from a relation, so you can then iterate in a for loop
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'careplans') ) 
+%}
+
+
+WITH cte_careplans_lower AS (
+
+    SELECT  
+
+        {% for column_name in column_names %}
+            "{{ column_name }}" as {{ column_name | lower }}
+        {% if not loop.last %},{% endif %}
+        {% endfor %}
+        
+    FROM {{ source('synthea','careplans') }}
+) 
+
+, cte_careplans_rename AS (
+
+    SELECT 
+        id AS careplan_id
+        , start AS careplan_start_date
+        , stop AS careplan_stop_date
+        , patient AS patient_id
+        , encounter AS encounter_id
+        , code AS careplan_code
+        , description AS careplan_description
+        , reasoncode AS careplan_reason_code
+        , reasondescription AS careplan_reason_description
+    FROM cte_careplans_lower
+
+)
+
+SELECT  * 
+FROM cte_careplans_rename

--- a/models/staging/synthea/stg_synthea__claims.sql
+++ b/models/staging/synthea/stg_synthea__claims.sql
@@ -1,0 +1,52 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'claims') ) 
+%}
+
+
+WITH cte_claims_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','claims') }}
+)
+
+, cte_claims_rename AS (
+
+    SELECT
+        id AS claim_id
+        , patientid AS patient_id
+        , providerid AS provider_id
+        , primarypatientinsuranceid AS primary_patient_insurance_id
+        , secondarypatientinsuranceid AS secondary_patient_insurance_id
+        , departmentid AS department_id
+        , patientdepartmentid AS patient_department_id
+        , diagnosis1 AS diagnosis_1
+        , diagnosis2 AS diagnosis_2
+        , diagnosis3 AS diagnosis_3
+        , diagnosis4 AS diagnosis_4
+        , diagnosis5 AS diagnosis_5
+        , diagnosis6 AS diagnosis_6
+        , diagnosis7 AS diagnosis_7
+        , diagnosis8 AS diagnosis_8
+        , referringproviderid AS referring_provider_id
+        , appointmentid AS encounter_id
+        , currentillnessdate AS current_illness_date
+        , servicedate AS service_date
+        , supervisingproviderid AS supervising_provider_id
+        , status1 AS claim_status_1
+        , status2 AS claim_status_2
+        , statusp AS claim_status_patient
+        , outstanding1 AS outstanding_1
+        , outstanding2 AS outstanding_2
+        , outstandingp AS outstanding_patient
+        , lastbilleddate1 AS last_billed_date_1
+        , lastbilleddate2 AS last_billed_date_2
+        , lastbilleddatep AS last_billed_date_patient
+        , healthcareclaimtypeid1 AS claim_type_id_1
+        , healthcareclaimtypeid2 AS claim_type_id_2
+    FROM cte_claims_lower
+
+)
+
+SELECT *
+FROM cte_claims_rename

--- a/models/staging/synthea/stg_synthea__claims.sql
+++ b/models/staging/synthea/stg_synthea__claims.sql
@@ -16,8 +16,14 @@ WITH cte_claims_lower AS (
         id AS claim_id
         , patientid AS patient_id
         , providerid AS provider_id
-        , primarypatientinsuranceid AS primary_patient_insurance_id
-        , secondarypatientinsuranceid AS secondary_patient_insurance_id
+        , CASE
+            WHEN primarypatientinsuranceid = '0' THEN NULL
+            ELSE primarypatientinsuranceid
+        END AS primary_patient_insurance_id
+        , CASE
+            WHEN secondarypatientinsuranceid = '0' THEN NULL
+            ELSE secondarypatientinsuranceid
+        END AS secondary_patient_insurance_id
         , departmentid AS department_id
         , patientdepartmentid AS patient_department_id
         , diagnosis1 AS diagnosis_1

--- a/models/staging/synthea/stg_synthea__claims_transactions.sql
+++ b/models/staging/synthea/stg_synthea__claims_transactions.sql
@@ -1,0 +1,60 @@
+-- Returns a list of the columns from a relation, so you can then iterate in a for loop
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'claims_transactions') ) 
+%}
+
+
+WITH cte_claims_transactions_lower AS (
+
+    SELECT  
+
+        {% for column_name in column_names %}
+            "{{ column_name }}" as {{ column_name | lower }}
+        {% if not loop.last %},{% endif %}
+        {% endfor %}
+        
+    FROM {{ source('synthea','claims_transactions') }}
+) 
+
+, cte_claims_transactions_rename AS (
+
+    SELECT 
+        id AS claim_transaction_id,
+        claimid AS claim_id,
+        chargeid AS charge_id,
+        patientid AS patient_id,
+        "type" AS transaction_type,
+        amount AS transaction_amount,
+        method AS transaction_method,
+        fromdate AS transaction_from_date,
+        todate AS transaction_to_date,
+        placeofservice AS place_of_service,
+        procedurecode AS procedure_code,
+        modifier1 AS procedure_code_modifier1,
+        modifier2 AS procedure_code_modifier2,
+        diagnosisref1 AS claim_diagnosis_ref1,
+        diagnosisref2 AS claim_diagnosis_ref2,
+        diagnosisref3 AS claim_diagnosis_ref3,
+        diagnosisref4 AS claim_diagnosis_ref4,
+        units AS service_units,
+        departmentid AS department_id,
+        notes AS transaction_notes,
+        unitamount AS per_unit_amount,
+        transferoutid AS transfer_out_id,
+        transfertype AS transfer_type,
+        payments AS payments,
+        adjustments AS adjustments,
+        transfers AS transfers,
+        outstanding AS outstanding,
+        appointmentid AS encounter_id,
+        linenote AS claim_transaction_line_note,
+        patientinsuranceid AS patient_insurance_id,
+        feescheduleid AS fee_schedule_id,
+        providerid AS provider_id,
+        supervisingproviderid AS supervising_provider_id
+    FROM cte_claims_transactions_lower
+
+)
+
+SELECT  * 
+FROM cte_claims_transactions_rename

--- a/models/staging/synthea/stg_synthea__claims_transactions.sql
+++ b/models/staging/synthea/stg_synthea__claims_transactions.sql
@@ -1,4 +1,3 @@
--- Returns a list of the columns from a relation, so you can then iterate in a for loop
 {% set column_names = 
     dbt_utils.get_filtered_columns_in_relation( source('synthea', 'claims_transactions') ) 
 %}
@@ -6,55 +5,55 @@
 
 WITH cte_claims_transactions_lower AS (
 
-    SELECT  
+    SELECT
 
-        {% for column_name in column_names %}
-            "{{ column_name }}" as {{ column_name | lower }}
-        {% if not loop.last %},{% endif %}
-        {% endfor %}
-        
+    {% for column_name in column_names %} -- noqa:disable=LT02
+        "{{ column_name }}" AS {{ column_name | lower }} -- noqa:disable=LT02
+        {% if not loop.last %},{% endif %} -- noqa:disable=LT02
+    {% endfor %} -- noqa:disable=LT02
+
     FROM {{ source('synthea','claims_transactions') }}
-) 
+)
 
 , cte_claims_transactions_rename AS (
 
-    SELECT 
-        id AS claim_transaction_id,
-        claimid AS claim_id,
-        chargeid AS charge_id,
-        patientid AS patient_id,
-        "type" AS transaction_type,
-        amount AS transaction_amount,
-        method AS transaction_method,
-        fromdate AS transaction_from_date,
-        todate AS transaction_to_date,
-        placeofservice AS place_of_service,
-        procedurecode AS procedure_code,
-        modifier1 AS procedure_code_modifier1,
-        modifier2 AS procedure_code_modifier2,
-        diagnosisref1 AS claim_diagnosis_ref1,
-        diagnosisref2 AS claim_diagnosis_ref2,
-        diagnosisref3 AS claim_diagnosis_ref3,
-        diagnosisref4 AS claim_diagnosis_ref4,
-        units AS service_units,
-        departmentid AS department_id,
-        notes AS transaction_notes,
-        unitamount AS per_unit_amount,
-        transferoutid AS transfer_out_id,
-        transfertype AS transfer_type,
-        payments AS payments,
-        adjustments AS adjustments,
-        transfers AS transfers,
-        outstanding AS outstanding,
-        appointmentid AS encounter_id,
-        linenote AS claim_transaction_line_note,
-        patientinsuranceid AS patient_insurance_id,
-        feescheduleid AS fee_schedule_id,
-        providerid AS provider_id,
-        supervisingproviderid AS supervising_provider_id
+    SELECT
+        id AS claim_transaction_id
+        , claimid AS claim_id
+        , chargeid AS charge_id
+        , patientid AS patient_id
+        , "type" AS transaction_type
+        , amount AS transaction_amount
+        , method AS transaction_method
+        , fromdate AS transaction_from_date
+        , todate AS transaction_to_date
+        , placeofservice AS place_of_service
+        , procedurecode AS procedure_code
+        , modifier1 AS procedure_code_modifier1
+        , modifier2 AS procedure_code_modifier2
+        , diagnosisref1 AS claim_diagnosis_ref1
+        , diagnosisref2 AS claim_diagnosis_ref2
+        , diagnosisref3 AS claim_diagnosis_ref3
+        , diagnosisref4 AS claim_diagnosis_ref4
+        , units AS service_units
+        , departmentid AS department_id
+        , notes AS transaction_notes
+        , unitamount AS per_unit_amount
+        , transferoutid AS transfer_out_id
+        , transfertype AS transfer_type
+        , payments
+        , adjustments
+        , transfers
+        , outstanding
+        , appointmentid AS encounter_id
+        , linenote AS claim_transaction_line_note
+        , patientinsuranceid AS patient_insurance_id
+        , feescheduleid AS fee_schedule_id
+        , providerid AS provider_id
+        , supervisingproviderid AS supervising_provider_id
     FROM cte_claims_transactions_lower
 
 )
 
-SELECT  * 
+SELECT *
 FROM cte_claims_transactions_rename

--- a/models/staging/synthea/stg_synthea__claims_transactions.sql
+++ b/models/staging/synthea/stg_synthea__claims_transactions.sql
@@ -24,12 +24,12 @@ WITH cte_claims_transactions_lower AS (
         , todate AS transaction_to_date
         , placeofservice AS place_of_service
         , procedurecode AS procedure_code
-        , modifier1 AS procedure_code_modifier1
-        , modifier2 AS procedure_code_modifier2
-        , diagnosisref1 AS claim_diagnosis_ref1
-        , diagnosisref2 AS claim_diagnosis_ref2
-        , diagnosisref3 AS claim_diagnosis_ref3
-        , diagnosisref4 AS claim_diagnosis_ref4
+        , modifier1 AS procedure_code_modifier_1
+        , modifier2 AS procedure_code_modifier_2
+        , diagnosisref1 AS claim_diagnosis_ref_1
+        , diagnosisref2 AS claim_diagnosis_ref_2
+        , diagnosisref3 AS claim_diagnosis_ref_3
+        , diagnosisref4 AS claim_diagnosis_ref_4
         , units AS service_units
         , departmentid AS department_id
         , notes AS transaction_notes

--- a/models/staging/synthea/stg_synthea__claims_transactions.sql
+++ b/models/staging/synthea/stg_synthea__claims_transactions.sql
@@ -6,12 +6,7 @@
 WITH cte_claims_transactions_lower AS (
 
     SELECT
-
-    {% for column_name in column_names %} -- noqa:disable=LT02
-        "{{ column_name }}" AS {{ column_name | lower }} -- noqa:disable=LT02
-        {% if not loop.last %},{% endif %} -- noqa:disable=LT02
-    {% endfor %} -- noqa:disable=LT02
-
+        {{ lowercase_columns(column_names) }}
     FROM {{ source('synthea','claims_transactions') }}
 )
 

--- a/models/staging/synthea/stg_synthea__conditions.sql
+++ b/models/staging/synthea/stg_synthea__conditions.sql
@@ -1,0 +1,27 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'conditions') ) 
+%}
+
+
+WITH cte_conditions_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','conditions') }}
+)
+
+, cte_conditions_rename AS (
+
+    SELECT
+        "start" AS condition_start_date
+        , "stop" AS condition_stop_date
+        , patient AS patient_id
+        , encounter AS encounter_id
+        , code AS condition_code
+        , "description" AS condition_description
+    FROM cte_conditions_lower
+
+)
+
+SELECT *
+FROM cte_conditions_rename

--- a/models/staging/synthea/stg_synthea__devices.sql
+++ b/models/staging/synthea/stg_synthea__devices.sql
@@ -1,0 +1,28 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'devices') ) 
+%}
+
+
+WITH cte_devices_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','devices') }}
+)
+
+, cte_devices_rename AS (
+
+    SELECT
+        "start" AS device_start_datetime
+        , "stop" AS device_stop_datetime
+        , patient AS patient_id
+        , encounter AS encounter_id
+        , code AS device_code
+        , "description" AS device_description
+        , udi
+    FROM cte_devices_lower
+
+)
+
+SELECT *
+FROM cte_devices_rename

--- a/models/staging/synthea/stg_synthea__encounters.sql
+++ b/models/staging/synthea/stg_synthea__encounters.sql
@@ -25,9 +25,9 @@ WITH cte_encounters_lower AS (
         , description AS encounter_description
         , base_encounter_cost
         , total_claim_cost AS total_encounter_cost
-        , payer_coverage
-        , reasoncode AS reason_code
-        , reasondescription AS reason_description
+        , payer_coverage AS encounter_payer_coverage
+        , reasoncode AS encounter_reason_code
+        , reasondescription AS encounter_reason_description
     FROM cte_encounters_lower
 
 )

--- a/models/staging/synthea/stg_synthea__encounters.sql
+++ b/models/staging/synthea/stg_synthea__encounters.sql
@@ -1,0 +1,36 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'encounters') ) 
+%}
+
+
+WITH cte_encounters_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','encounters') }}
+)
+
+, cte_encounters_rename AS (
+
+    SELECT
+        id AS encounter_id
+        , start AS encounter_start_datetime
+        , stop AS encounter_stop_datetime
+        , patient AS patient_id
+        , organization AS organization_id
+        , provider AS provider_id
+        , payer AS payer_id
+        , encounterclass AS encounter_class
+        , code AS encounter_code
+        , description AS encounter_description
+        , base_encounter_cost
+        , total_claim_cost AS total_encounter_cost
+        , payer_coverage
+        , reasoncode AS reason_code
+        , reasondescription AS reason_description
+    FROM cte_encounters_lower
+
+)
+
+SELECT *
+FROM cte_encounters_rename

--- a/models/staging/synthea/stg_synthea__imaging_studies.sql
+++ b/models/staging/synthea/stg_synthea__imaging_studies.sql
@@ -14,17 +14,17 @@ WITH cte_imaging_studies_lower AS (
 
     SELECT
         "id" AS imaging_id
-        , "date" AS imaging_date
+        , "date" AS imaging_datetime
         , patient AS patient_id
         , encounter AS encounter_id
-        , series_uid AS imaging_series_uid
-        , bodysite_code AS imaging_bodysite_code
-        , bodysite_description AS imaging_bodysite_description
-        , modality_code AS imaging_modality_code
-        , modality_description AS imaging_modality_description
-        , instance_uid AS imaging_instance_uid
-        , sop_code AS imaging_sop_code
-        , sop_description AS imaging_sop_description
+        , series_uid
+        , bodysite_code
+        , bodysite_description
+        , modality_code
+        , modality_description
+        , instance_uid
+        , sop_code
+        , sop_description
         , procedure_code AS imaging_procedure_code
     FROM cte_imaging_studies_lower
 

--- a/models/staging/synthea/stg_synthea__imaging_studies.sql
+++ b/models/staging/synthea/stg_synthea__imaging_studies.sql
@@ -1,0 +1,34 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'imaging_studies') ) 
+%}
+
+
+WITH cte_imaging_studies_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','imaging_studies') }}
+)
+
+, cte_imaging_studies_rename AS (
+
+    SELECT
+        "id" AS imaging_id
+        , "date" AS imaging_date
+        , patient AS patient_id
+        , encounter AS encounter_id
+        , series_uid AS imaging_series_uid
+        , bodysite_code AS imaging_bodysite_code
+        , bodysite_description AS imaging_bodysite_description
+        , modality_code AS imaging_modality_code
+        , modality_description AS imaging_modality_description
+        , instance_uid AS imaging_instance_uid
+        , sop_code AS imaging_sop_code
+        , sop_description AS imaging_sop_description
+        , procedure_code AS imaging_procedure_code
+    FROM cte_imaging_studies_lower
+
+)
+
+SELECT *
+FROM cte_imaging_studies_rename

--- a/models/staging/synthea/stg_synthea__immunizations.sql
+++ b/models/staging/synthea/stg_synthea__immunizations.sql
@@ -1,0 +1,27 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'immunizations') ) 
+%}
+
+
+WITH cte_immunizations_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','immunizations') }}
+)
+
+, cte_immunizations_rename AS (
+
+    SELECT
+        "date" AS immunization_date
+        , patient AS patient_id
+        , encounter AS encounter_id
+        , code AS immunization_code
+        , "description" AS immunization_description
+        , base_cost AS immunization_base_cost
+    FROM cte_immunizations_lower
+
+)
+
+SELECT *
+FROM cte_immunizations_rename

--- a/models/staging/synthea/stg_synthea__medications.sql
+++ b/models/staging/synthea/stg_synthea__medications.sql
@@ -13,8 +13,8 @@ WITH cte_medications_lower AS (
 , cte_medications_rename AS (
 
     SELECT
-        "start" AS medication_start_date
-        , "stop" AS medication_stop_date
+        "start" AS medication_start_datetime
+        , "stop" AS medication_stop_datetime
         , patient AS patient_id
         , payer AS payer_id
         , encounter AS encounter_id
@@ -22,7 +22,7 @@ WITH cte_medications_lower AS (
         , "description" AS medication_description
         , base_cost AS medication_base_cost
         , payer_coverage AS medication_payer_coverage
-        , dispenses AS medication_dispenses
+        , dispenses
         , totalcost AS medication_total_cost
         , reasoncode AS medication_reason_code
         , reasondescription AS medication_reason_description

--- a/models/staging/synthea/stg_synthea__medications.sql
+++ b/models/staging/synthea/stg_synthea__medications.sql
@@ -1,0 +1,34 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'medications') ) 
+%}
+
+
+WITH cte_medications_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','medications') }}
+)
+
+, cte_medications_rename AS (
+
+    SELECT
+        "start" AS medication_start_date
+        , "stop" AS medication_stop_date
+        , patient AS patient_id
+        , payer AS payer_id
+        , encounter AS encounter_id
+        , code AS medication_code
+        , "description" AS medication_description
+        , base_cost AS medication_base_cost
+        , payer_coverage AS medication_payer_coverage
+        , dispenses AS medication_dispenses
+        , totalcost AS medication_total_cost
+        , reasoncode AS medication_reason_code
+        , reasondescription AS medication_reason_description
+    FROM cte_medications_lower
+
+)
+
+SELECT *
+FROM cte_medications_rename

--- a/models/staging/synthea/stg_synthea__observations.sql
+++ b/models/staging/synthea/stg_synthea__observations.sql
@@ -1,0 +1,30 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'observations') ) 
+%}
+
+
+WITH cte_observations_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','observations') }}
+)
+
+, cte_observations_rename AS (
+
+    SELECT
+        "date" AS observation_date
+        , patient AS patient_id
+        , encounter AS encounter_id
+        , category AS observation_category
+        , code AS observation_code
+        , "description" AS observation_description
+        , "value" AS observation_value
+        , units AS observation_units
+        , type AS observation_type
+    FROM cte_observations_lower
+
+)
+
+SELECT *
+FROM cte_observations_rename

--- a/models/staging/synthea/stg_synthea__observations.sql
+++ b/models/staging/synthea/stg_synthea__observations.sql
@@ -13,7 +13,7 @@ WITH cte_observations_lower AS (
 , cte_observations_rename AS (
 
     SELECT
-        "date" AS observation_date
+        "date" AS observation_datetime
         , patient AS patient_id
         , encounter AS encounter_id
         , category AS observation_category
@@ -21,7 +21,7 @@ WITH cte_observations_lower AS (
         , "description" AS observation_description
         , "value" AS observation_value
         , units AS observation_units
-        , type AS observation_type
+        , "type" AS observation_value_type
     FROM cte_observations_lower
 
 )

--- a/models/staging/synthea/stg_synthea__organizations.sql
+++ b/models/staging/synthea/stg_synthea__organizations.sql
@@ -19,8 +19,8 @@ WITH cte_organizations_lower AS (
         , city AS organization_city
         , state AS organization_state
         , zip AS organization_zip
-        , lat AS organization_lat
-        , lon AS organization_lon
+        , lat AS organization_latitude
+        , lon AS organization_longitude
         , phone AS organization_phone
         , revenue AS organization_revenue
         , utilization AS organization_utilization

--- a/models/staging/synthea/stg_synthea__organizations.sql
+++ b/models/staging/synthea/stg_synthea__organizations.sql
@@ -1,0 +1,32 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'organizations') ) 
+%}
+
+
+WITH cte_organizations_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','organizations') }}
+)
+
+, cte_organizations_rename AS (
+
+    SELECT
+        id AS organization_id
+        , name AS organization_name
+        , address AS organization_address
+        , city AS organization_city
+        , state AS organization_state
+        , zip AS organization_zip
+        , lat AS organization_lat
+        , lon AS organization_lon
+        , phone AS organization_phone
+        , revenue AS organization_revenue
+        , utilization AS organization_utilization
+    FROM cte_organizations_lower
+
+)
+
+SELECT *
+FROM cte_organizations_rename

--- a/models/staging/synthea/stg_synthea__patients.sql
+++ b/models/staging/synthea/stg_synthea__patients.sql
@@ -20,21 +20,21 @@ WITH cte_patients_lower AS (
 
     SELECT 
         id AS patient_id
-        , birthdate AS patient_birth_date
-        , deathdate AS patient_death_date
-        , ssn AS patient_ssn
-        , drivers AS patient_drivers_license_number
-        , passport AS patient_passport_number
+        , birthdate AS birth_date
+        , deathdate AS death_date
+        , ssn AS ssn
+        , drivers AS drivers_license_number
+        , passport AS passport_number
         , prefix AS patient_prefix
         , first AS patient_first_name
         , last AS patient_last_name
         , suffix AS patient_suffix
-        , maiden AS patient_maiden_name
-        , marital AS patient_marital_status
-        , race AS patient_race
-        , ethnicity AS patient_ethnicity
-        , gender AS patient_gender
-        , birthplace AS patient_birthplace
+        , maiden AS maiden_name
+        , marital AS marital_status
+        , race AS race
+        , ethnicity AS ethnicity
+        , gender AS gender
+        , birthplace AS birthplace
         , address AS patient_address
         , city AS patient_city
         , state AS patient_state
@@ -42,8 +42,8 @@ WITH cte_patients_lower AS (
         , zip AS patient_zip
         , lat AS patient_latitude
         , lon AS patient_longitude
-        , healthcare_expenses AS patient_healthcare_expenses
-        , healthcare_coverage AS patient_healthcare_coverage
+        , healthcare_expenses AS healthcare_expenses
+        , healthcare_coverage AS healthcare_coverage
     FROM cte_patients_lower
 
 )

--- a/models/staging/synthea/stg_synthea__patients.sql
+++ b/models/staging/synthea/stg_synthea__patients.sql
@@ -6,12 +6,7 @@
 WITH cte_patients_lower AS (
 
     SELECT
-
-    {% for column_name in column_names %} -- noqa:disable=LT02
-        "{{ column_name }}" AS {{ column_name | lower }} -- noqa:disable=LT02
-        {% if not loop.last %},{% endif %} -- noqa:disable=LT02
-    {% endfor %} -- noqa:disable=LT02
-
+        {{ lowercase_columns(column_names) }}
     FROM {{ source('synthea','patients') }}
 )
 

--- a/models/staging/synthea/stg_synthea__patients.sql
+++ b/models/staging/synthea/stg_synthea__patients.sql
@@ -1,4 +1,3 @@
--- Returns a list of the columns from a relation, so you can then iterate in a for loop
 {% set column_names = 
     dbt_utils.get_filtered_columns_in_relation( source('synthea', 'patients') ) 
 %}
@@ -6,47 +5,47 @@
 
 WITH cte_patients_lower AS (
 
-    SELECT  
+    SELECT
 
-        {% for column_name in column_names %}
-            "{{ column_name }}" as {{ column_name | lower }}
-        {% if not loop.last %},{% endif %}
-        {% endfor %}
-        
+    {% for column_name in column_names %} -- noqa:disable=LT02
+        "{{ column_name }}" AS {{ column_name | lower }} -- noqa:disable=LT02
+        {% if not loop.last %},{% endif %} -- noqa:disable=LT02
+    {% endfor %} -- noqa:disable=LT02
+
     FROM {{ source('synthea','patients') }}
-) 
+)
 
 , cte_patients_rename AS (
 
-    SELECT 
+    SELECT
         id AS patient_id
         , birthdate AS birth_date
         , deathdate AS death_date
-        , ssn AS ssn
+        , ssn
         , drivers AS drivers_license_number
         , passport AS passport_number
         , prefix AS patient_prefix
-        , first AS patient_first_name
-        , last AS patient_last_name
+        , "first" AS patient_first_name
+        , "last" AS patient_last_name
         , suffix AS patient_suffix
         , maiden AS maiden_name
         , marital AS marital_status
-        , race AS race
-        , ethnicity AS ethnicity
-        , gender AS gender
-        , birthplace AS birthplace
-        , address AS patient_address
+        , race
+        , ethnicity
+        , gender
+        , birthplace
+        , "address" AS patient_address
         , city AS patient_city
-        , state AS patient_state
+        , "state" AS patient_state
         , county AS patient_county
         , zip AS patient_zip
         , lat AS patient_latitude
         , lon AS patient_longitude
-        , healthcare_expenses AS healthcare_expenses
-        , healthcare_coverage AS healthcare_coverage
+        , healthcare_expenses
+        , healthcare_coverage
     FROM cte_patients_lower
 
 )
 
-SELECT  * 
+SELECT *
 FROM cte_patients_rename

--- a/models/staging/synthea/stg_synthea__patients.sql
+++ b/models/staging/synthea/stg_synthea__patients.sql
@@ -27,7 +27,7 @@ WITH cte_patients_lower AS (
         , marital AS marital_status
         , race
         , ethnicity
-        , gender
+        , gender AS patient_gender
         , birthplace
         , "address" AS patient_address
         , city AS patient_city

--- a/models/staging/synthea/stg_synthea__payer_transitions.sql
+++ b/models/staging/synthea/stg_synthea__payer_transitions.sql
@@ -15,10 +15,10 @@ WITH cte_payer_transitions_lower AS (
     SELECT
         patient AS patient_id
         , memberid AS member_id
-        , start_year AS payer_start_year
-        , end_year AS payer_end_year
+        , start_year AS coverage_start_year
+        , end_year AS coverage_end_year
         , payer AS payer_id
-        , SECONDARY_PAYER AS secondary_payer_id
+        , secondary_payer AS secondary_payer_id
         , "ownership" AS plan_owner_relationship
         , ownername AS plan_owner_name
     FROM cte_payer_transitions_lower

--- a/models/staging/synthea/stg_synthea__payer_transitions.sql
+++ b/models/staging/synthea/stg_synthea__payer_transitions.sql
@@ -1,0 +1,29 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'payer_transitions') ) 
+%}
+
+
+WITH cte_payer_transitions_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','payer_transitions') }}
+)
+
+, cte_payer_transitions_rename AS (
+
+    SELECT
+        patient AS patient_id
+        , memberid AS member_id
+        , start_year AS payer_start_year
+        , end_year AS payer_end_year
+        , payer AS payer_id
+        , SECONDARY_PAYER AS secondary_payer_id
+        , "ownership" AS plan_owner_relationship
+        , ownername AS plan_owner_name
+    FROM cte_payer_transitions_lower
+
+)
+
+SELECT *
+FROM cte_payer_transitions_rename

--- a/models/staging/synthea/stg_synthea__payers.sql
+++ b/models/staging/synthea/stg_synthea__payers.sql
@@ -22,12 +22,12 @@ WITH cte_payers_lower AS (
         , amount_covered AS payer_amount_covered
         , amount_uncovered AS payer_amount_uncovered
         , revenue AS payer_revenue
-        , covered_encounters AS payer_covered_encounters
-        , uncovered_encounters AS payer_uncovered_encounters
-        , covered_procedures AS payer_covered_procedures
-        , uncovered_procedures AS payer_uncovered_procedures
-        , covered_immunizations AS payer_covered_immunizations
-        , uncovered_immunizations AS payer_uncovered_immunizations
+        , covered_encounters
+        , uncovered_encounters
+        , covered_procedures
+        , uncovered_procedures
+        , covered_immunizations
+        , uncovered_immunizations
         , unique_customers
         , qols_avg
         , member_months AS payer_member_months

--- a/models/staging/synthea/stg_synthea__payers.sql
+++ b/models/staging/synthea/stg_synthea__payers.sql
@@ -1,0 +1,39 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'payers') ) 
+%}
+
+
+WITH cte_payers_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','payers') }}
+)
+
+, cte_payers_rename AS (
+
+    SELECT
+        id AS payer_id
+        , "name" AS payer_name
+        , city AS payer_city
+        , state_headquartered AS payer_state_headquartered
+        , zip AS payer_zip
+        , phone AS payer_phone
+        , amount_covered AS payer_amount_covered
+        , amount_uncovered AS payer_amount_uncovered
+        , revenue AS payer_revenue
+        , covered_encounters AS payer_covered_encounters
+        , uncovered_encounters AS payer_uncovered_encounters
+        , covered_procedures AS payer_covered_procedures
+        , uncovered_procedures AS payer_uncovered_procedures
+        , covered_immunizations AS payer_covered_immunizations
+        , uncovered_immunizations AS payer_uncovered_immunizations
+        , unique_customers
+        , qols_avg
+        , member_months AS payer_member_months
+    FROM cte_payers_lower
+
+)
+
+SELECT *
+FROM cte_payers_rename

--- a/models/staging/synthea/stg_synthea__procedures.sql
+++ b/models/staging/synthea/stg_synthea__procedures.sql
@@ -13,8 +13,8 @@ WITH cte_procedures_lower AS (
 , cte_procedures_rename AS (
 
     SELECT
-        "start" AS procedure_start_date
-        , "stop" AS procedure_stop_date
+        "start" AS procedure_start_datetime
+        , "stop" AS procedure_stop_datetime
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS procedure_code

--- a/models/staging/synthea/stg_synthea__procedures.sql
+++ b/models/staging/synthea/stg_synthea__procedures.sql
@@ -1,0 +1,30 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'procedures') ) 
+%}
+
+
+WITH cte_procedures_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','procedures') }}
+)
+
+, cte_procedures_rename AS (
+
+    SELECT
+        "start" AS procedure_start_date
+        , "stop" AS procedure_stop_date
+        , patient AS patient_id
+        , encounter AS encounter_id
+        , code AS procedure_code
+        , "description" AS procedure_description
+        , base_cost AS procedure_base_cost
+        , reasoncode AS procedure_reason_code
+        , reasondescription AS procedure_reason_description
+    FROM cte_procedures_lower
+
+)
+
+SELECT *
+FROM cte_procedures_rename

--- a/models/staging/synthea/stg_synthea__providers.sql
+++ b/models/staging/synthea/stg_synthea__providers.sql
@@ -1,0 +1,33 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'providers') ) 
+%}
+
+
+WITH cte_providers_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','providers') }}
+)
+
+, cte_providers_rename AS (
+
+    SELECT
+        id AS provider_id
+        , organization AS organization_id
+        , "name" AS provider_name
+        , gender AS provider_gender
+        , speciality AS provider_specialty
+        , "address" AS provider_address
+        , city AS provider_city
+        , "state" AS provider_state
+        , zip AS provider_zip
+        , lat AS provider_lat
+        , lon AS provider_lon
+        , utilization AS provider_utilization
+    FROM cte_providers_lower
+
+)
+
+SELECT *
+FROM cte_providers_rename

--- a/models/staging/synthea/stg_synthea__providers.sql
+++ b/models/staging/synthea/stg_synthea__providers.sql
@@ -22,8 +22,8 @@ WITH cte_providers_lower AS (
         , city AS provider_city
         , "state" AS provider_state
         , zip AS provider_zip
-        , lat AS provider_lat
-        , lon AS provider_lon
+        , lat AS provider_latitude
+        , lon AS provider_longitude
         , utilization AS provider_utilization
     FROM cte_providers_lower
 

--- a/models/staging/synthea/stg_synthea__supplies.sql
+++ b/models/staging/synthea/stg_synthea__supplies.sql
@@ -1,0 +1,27 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('synthea', 'supplies') ) 
+%}
+
+
+WITH cte_supplies_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('synthea','supplies') }}
+)
+
+, cte_supplies_rename AS (
+
+    SELECT
+        "date" AS supply_date
+        , patient AS patient_id
+        , encounter AS encounter_id
+        , code AS supply_code
+        , "description" AS supply_description
+        , quantity AS supply_quantity
+    FROM cte_supplies_lower
+
+)
+
+SELECT *
+FROM cte_supplies_rename


### PR DESCRIPTION
- Adds stg models for careplans, claims_transactions, claims, devices, and encounters (#11 , #12, #13, #15, #16)
- Updates column names in person stg model to remove unnecessary person_ prefix from some columns. Only need tablename prefix for potentially ambiguous column names (i.e., used in other source tables)
- Adds initial style guide (#8)
- Adds SQLFluff (#7) and related documentation
- Creates macro for lowercasing column names

Also: #32 