### PR TITLE
Add 3 missing tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ dbt debug
 dbt deps
 ```
 
- 5. **If you'd like to run the default ETL using the pre-seeded Synthea dataset,** run `dbt seed` to load the CSVs with the Synthea dataset and vocabulary data. This materializes the seed CSVs as tables in your target schema (vocab) and a _synthea schema (Synthea tables).  **Then, skip to step 8 below.**
+ 5. **If you'd like to run the default ETL using the pre-seeded Synthea dataset,** run `dbt seed` to load the CSVs with the Synthea dataset and vocabulary data. This materializes the seed CSVs as tables in your target schema (vocab) and a _synthea schema (Synthea tables).  **Then, skip to step 9 below.**
 ```bash
 dbt seed
 ```
@@ -81,12 +81,17 @@ file_dict=$(python3 scripts/python/get_csv_filepaths.py path/to/vocab/csvs)
 dbt run-operation load_data_duckdb --args "{file_dict: $file_dict, vocab_tables: true}"
 ```
 
- 8. Build the OMOP tables:
+ 8. Seed the location mapper:
+```bash
+dbt seed --select states
+```
+
+ 9. Build the OMOP tables:
 ```bash
 dbt run
 ```
 
- 9. Run tests:
+ 10. Run tests:
 ```bash
 dbt test
 ```
@@ -122,7 +127,7 @@ dbt debug
 dbt deps
 ```
 
- 5. **If you'd like to run the default ETL using the pre-seeded Synthea dataset,** run `dbt seed` to load the CSVs with the Synthea dataset and vocabulary data. This materializes the seed CSVs as tables in your target schema (vocab) and a _synthea schema (Synthea tables).  **Then, skip to step 9 below.**
+ 5. **If you'd like to run the default ETL using the pre-seeded Synthea dataset,** run `dbt seed` to load the CSVs with the Synthea dataset and vocabulary data. This materializes the seed CSVs as tables in your target schema (vocab) and a _synthea schema (Synthea tables).  **Then, skip to step 10 below.**
 ```bash
 dbt seed
 ```
@@ -137,12 +142,17 @@ dbt run-operation create_synthea_tables
 
  8. **[BYO DATA ONLY]** Use the technology/package of your choice to load the OMOP vocabulary and raw Synthea files into these newly-created tables. **NOTE only Synthea v3.0.0 is supported at this time.**
 
- 9. Build the OMOP tables:
+ 9. Seed the location mapper:
+```bash
+dbt seed --select states
+```
+
+ 10. Build the OMOP tables:
 ```bash
 dbt run
 ```
 
- 10. Run tests:
+ 11. Run tests:
 ```bash
 dbt test
 ```

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,6 +23,9 @@ models:
 
 seeds:
   synthea_omop_etl:
+    map:
+      +enabled: true
+      +schema: map_seeds
     vocabulary:
       +enabled: true
       +schema: vocab_seeds

--- a/models/omop/care_site.sql
+++ b/models/omop/care_site.sql
@@ -1,0 +1,8 @@
+SELECT
+    ROW_NUMBER() OVER (ORDER BY organization_id) AS care_site_id
+    , organization_name AS care_site_name
+    , 0 AS place_of_service_concept_id
+    , CAST(NULL AS INTEGER) AS location_id
+    , organization_id AS care_site_source_value
+    , CAST(NULL AS VARCHAR) AS place_of_service_source_value
+FROM {{ ref('stg_synthea__organizations') }}

--- a/models/omop/location.sql
+++ b/models/omop/location.sql
@@ -1,0 +1,11 @@
+SELECT
+    ROW_NUMBER() OVER () AS location_id
+    , CAST(NULL AS VARCHAR) AS address_1
+    , CAST(NULL AS VARCHAR) AS address_2
+    , p.patient_city AS city
+    , s.state_abbreviation AS state
+    , CAST(NULL AS VARCHAR) AS county
+    , p.patient_zip AS zip
+    , p.patient_zip AS location_source_value
+FROM {{ ref('stg_synthea__patients') }} AS p
+LEFT JOIN {{ ref('stg_map__states') }} AS s ON p.patient_state = s.state_name

--- a/models/staging/map/_map__models.yml
+++ b/models/staging/map/_map__models.yml
@@ -1,0 +1,8 @@
+models:
+  - name: stg_map__states
+    description: State name to abbreviation mapper
+    columns:
+      - name: state_name
+        data_type: text
+      - name: state_abbreviation
+        data_type: text

--- a/models/staging/map/_map__sources.yml
+++ b/models/staging/map/_map__sources.yml
@@ -1,0 +1,7 @@
+version: 2
+
+sources:
+  - name: map
+    schema: "{{ target.schema ~ '_map_seeds' }}"
+    tables:
+      - name: states

--- a/models/staging/map/stg_map__states.sql
+++ b/models/staging/map/stg_map__states.sql
@@ -1,0 +1,14 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('map', 'states') ) 
+%}
+
+
+WITH cte_states_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('map','states') }}
+)
+
+SELECT *
+FROM cte_states_lower

--- a/models/staging/vocabulary/_vocabulary__model.yml
+++ b/models/staging/vocabulary/_vocabulary__model.yml
@@ -75,3 +75,14 @@ models:
       - name: valid_start_date
       - name: valid_end_date
       - name: invalid_reason
+  - name: stg_vocabulary__source_to_concept_map
+    columns:
+      - name: source_code
+      - name: source_vocabulary_id
+      - name: source_code_description
+      - name: target_concept_id
+      - name: target_vocabulary_id
+      - name: target_domain_id
+      - name: valid_start_date
+      - name: valid_end_date
+      - name: invalid_reason

--- a/models/staging/vocabulary/_vocabulary__sources.yml
+++ b/models/staging/vocabulary/_vocabulary__sources.yml
@@ -13,3 +13,4 @@ sources:
       - name: drug_strength
       - name: relationship
       - name: vocabulary
+      - name: source_to_concept_map

--- a/models/staging/vocabulary/stg_vocabulary__source_to_concept_map.sql
+++ b/models/staging/vocabulary/stg_vocabulary__source_to_concept_map.sql
@@ -1,0 +1,14 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('vocabulary', 'source_to_concept_map') ) 
+%}
+
+
+WITH cte_source_to_concept_map_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('vocabulary','source_to_concept_map') }}
+)
+
+SELECT *
+FROM cte_source_to_concept_map_lower

--- a/seeds/map/states.csv
+++ b/seeds/map/states.csv
@@ -1,0 +1,52 @@
+state_name,state_abbreviation
+Alabama,AL
+Alaska,AK
+Arizona,AZ
+Arkansas,AR
+California,CA
+Colorado,CO
+Connecticut,CT
+Delaware,DE
+District of Columbia,DC
+Florida,FL
+Georgia,GA
+Hawaii,HI
+Idaho,ID
+Illinois,IL
+Indiana,IN
+Iowa,IA
+Kansas,KS
+Kentucky,KY
+Louisiana,LA
+Maine,ME
+Maryland,MD
+Massachusetts,MA
+Michigan,MI
+Minnesota,MN
+Mississippi,MS
+Missouri,MO
+Montana,MT
+Nebraska,NE
+Nevada,NV
+New Hampshire,NH
+New Jersey,NJ
+New Mexico,NM
+New York,NY
+North Carolina,NC
+North Dakota,ND
+Ohio,OH
+Oklahoma,OK
+Oregon,OR
+Pennsylvania,PA
+Rhode Island,RI
+South Carolina,SC
+South Dakota,SD
+Tennessee,TN
+Texas,TX
+Utah,UT
+Vermont,VT
+Virginia,VA
+Washington,WA
+West Virginia,WV
+Wisconsin,WI
+Wyoming,WY

--- a/seeds/vocabulary/source_to_concept_map.csv
+++ b/seeds/vocabulary/source_to_concept_map.csv
@@ -1,0 +1,1 @@
+source_code,source_concept_id,source_vocabulary_id,source_code_description,target_concept_id,target_vocabulary_id,valid_start_date,valid_end_date,invalid_reason


### PR DESCRIPTION
We were missing source_to_concept_map (empty), care_site, and location. This PR adds the models for those tables - mirroring SQL from ETL-Synthea.  The state mapper is added as a seed file :)
