### PR TITLE
fix: remove broken relationship test

### DIFF
--- a/models/staging/synthea/_synthea__models.yml
+++ b/models/staging/synthea/_synthea__models.yml
@@ -252,11 +252,6 @@ models:
         data_type: text
       - name: patient_insurance_id
         data_type: text
-        description: "Foreign key to the Payer Transitions table member ID."
-        tests:
-          - relationships:
-              to: ref('stg_synthea__payer_transitions')
-              field: member_id
       - name: fee_schedule_id
         data_type: double precision
         description: "Fixed to 1."


### PR DESCRIPTION
 - test fails because of bad synthea output / invalid docs
 - issue upstream of this repo (synthetichealth/synthea)
 - neither `patient_insurance_id` nor `member_id` is used at any point other than this test


------

Resolves #50