### PR TITLE
Remove conditional build of vocab models

### DIFF
--- a/models/omop/concept.sql
+++ b/models/omop/concept.sql
@@ -1,3 +1,1 @@
-{{ config(enabled=var('seed_source', true)) }}
-
 SELECT * FROM {{ ref('stg_vocabulary__concept') }}

--- a/models/omop/concept_ancestor.sql
+++ b/models/omop/concept_ancestor.sql
@@ -1,3 +1,1 @@
-{{ config(enabled=var('seed_source', true)) }}
-
 SELECT * FROM {{ ref('stg_vocabulary__concept_ancestor') }}

--- a/models/omop/concept_class.sql
+++ b/models/omop/concept_class.sql
@@ -1,3 +1,1 @@
-{{ config(enabled=var('seed_source', true)) }}
-
 SELECT * FROM {{ ref('stg_vocabulary__concept_class') }}

--- a/models/omop/concept_relationship.sql
+++ b/models/omop/concept_relationship.sql
@@ -1,3 +1,1 @@
-{{ config(enabled=var('seed_source', true)) }}
-
 SELECT * FROM {{ ref('stg_vocabulary__concept_relationship') }}

--- a/models/omop/concept_synonym.sql
+++ b/models/omop/concept_synonym.sql
@@ -1,3 +1,1 @@
-{{ config(enabled=var('seed_source', true)) }}
-
 SELECT * FROM {{ ref('stg_vocabulary__concept_synonym') }}

--- a/models/omop/domain.sql
+++ b/models/omop/domain.sql
@@ -1,3 +1,1 @@
-{{ config(enabled=var('seed_source', true)) }}
-
 SELECT * FROM {{ ref('stg_vocabulary__domain') }}

--- a/models/omop/drug_strength.sql
+++ b/models/omop/drug_strength.sql
@@ -1,3 +1,1 @@
-{{ config(enabled=var('seed_source', true)) }}
-
 SELECT * FROM {{ ref('stg_vocabulary__drug_strength') }}

--- a/models/omop/relationship.sql
+++ b/models/omop/relationship.sql
@@ -1,3 +1,1 @@
-{{ config(enabled=var('seed_source', true)) }}
-
 SELECT * FROM {{ ref('stg_vocabulary__relationship') }}

--- a/models/omop/source_to_concept_map.sql
+++ b/models/omop/source_to_concept_map.sql
@@ -1,0 +1,1 @@
+SELECT * FROM {{ ref('stg_vocabulary__source_to_concept_map') }}

--- a/models/omop/vocabulary.sql
+++ b/models/omop/vocabulary.sql
@@ -1,3 +1,1 @@
-{{ config(enabled=var('seed_source', true)) }}
-
 SELECT * FROM {{ ref('stg_vocabulary__vocabulary') }}


### PR DESCRIPTION
Vocab models now always build, for both seed source and BYOD.  See: https://github.com/OHDSI/dbt-synthea/pull/61#issuecomment-2381439006