### PR TITLE
fix: use explicit seed types or null type casts where necessary for postgres

### DIFF
--- a/models/intermediate/int__person.sql
+++ b/models/intermediate/int__person.sql
@@ -19,9 +19,9 @@ SELECT
         WHEN upper(p.ethnicity) = 'NONHISPANIC' THEN 38003564
         ELSE 0
     END AS ethnicity_concept_id
-    , cast(NULL AS INTEGER) AS location_id
-    , cast(NULL AS INTEGER) AS provider_id
-    , cast(NULL AS INTEGER) AS care_site_id
+    , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS location_id
+    , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS provider_id
+    , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS care_site_id
     , p.patient_id AS person_source_value
     , p.patient_gender AS gender_source_value
     , 0 AS gender_source_concept_id

--- a/models/intermediate/int__person.sql
+++ b/models/intermediate/int__person.sql
@@ -19,9 +19,9 @@ SELECT
         WHEN upper(p.ethnicity) = 'NONHISPANIC' THEN 38003564
         ELSE 0
     END AS ethnicity_concept_id
-    , NULL AS location_id
-    , NULL AS provider_id
-    , NULL AS care_site_id
+    , cast(NULL AS INTEGER) AS location_id
+    , cast(NULL AS INTEGER) AS provider_id
+    , cast(NULL AS INTEGER) AS care_site_id
     , p.patient_id AS person_source_value
     , p.patient_gender AS gender_source_value
     , 0 AS gender_source_concept_id

--- a/models/omop/visit_detail.sql
+++ b/models/omop/visit_detail.sql
@@ -21,7 +21,7 @@ SELECT
     , av.visit_end_date AS visit_detail_end_datetime
     , 32827 AS visit_detail_type_concept_id
     , pr.provider_id
-    , cast(NULL AS INTEGER) AS care_site_id
+    , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS care_site_id
     , 0 AS admitted_from_concept_id
     , 0 AS discharged_to_concept_id
     , lag(av.visit_occurrence_id)
@@ -34,7 +34,7 @@ SELECT
     , 0 AS visit_detail_source_concept_id
     , NULL AS admitted_from_source_value
     , NULL AS discharged_to_source_value
-    , cast(NULL AS INTEGER) AS parent_visit_detail_id
+    , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS parent_visit_detail_id
     , av.visit_occurrence_id
 FROM {{ ref( 'int__all_visits') }} AS av
 INNER JOIN {{ ref( 'person') }} AS p

--- a/models/omop/visit_detail.sql
+++ b/models/omop/visit_detail.sql
@@ -21,7 +21,7 @@ SELECT
     , av.visit_end_date AS visit_detail_end_datetime
     , 32827 AS visit_detail_type_concept_id
     , pr.provider_id
-    , null AS care_site_id
+    , cast(NULL AS INTEGER) AS care_site_id
     , 0 AS admitted_from_concept_id
     , 0 AS discharged_to_concept_id
     , lag(av.visit_occurrence_id)
@@ -32,9 +32,9 @@ SELECT
     + 1000000 AS preceding_visit_detail_id
     , av.encounter_id AS visit_detail_source_value
     , 0 AS visit_detail_source_concept_id
-    , null AS admitted_from_source_value
-    , null AS discharged_to_source_value
-    , null AS parent_visit_detail_id
+    , NULL AS admitted_from_source_value
+    , NULL AS discharged_to_source_value
+    , cast(NULL AS INTEGER) AS parent_visit_detail_id
     , av.visit_occurrence_id
 FROM {{ ref( 'int__all_visits') }} AS av
 INNER JOIN {{ ref( 'person') }} AS p

--- a/models/omop/visit_occurrence.sql
+++ b/models/omop/visit_occurrence.sql
@@ -16,7 +16,7 @@ SELECT
     , av.visit_end_date AS visit_end_datetime
     , 32827 AS visit_type_concept_id
     , pr.provider_id
-    , cast(NULL AS INTEGER) AS care_site_id
+    , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS care_site_id
     , av.encounter_id AS visit_source_value
     , 0 AS visit_source_concept_id
     , 0 AS admitted_from_concept_id

--- a/models/omop/visit_occurrence.sql
+++ b/models/omop/visit_occurrence.sql
@@ -16,13 +16,13 @@ SELECT
     , av.visit_end_date AS visit_end_datetime
     , 32827 AS visit_type_concept_id
     , pr.provider_id
-    , null AS care_site_id
+    , cast(NULL AS INTEGER) AS care_site_id
     , av.encounter_id AS visit_source_value
     , 0 AS visit_source_concept_id
     , 0 AS admitted_from_concept_id
-    , null AS admitted_from_source_value
+    , NULL AS admitted_from_source_value
     , 0 AS discharged_to_concept_id
-    , null AS discharged_to_source_value
+    , NULL AS discharged_to_source_value
     , lag(av.visit_occurrence_id)
         OVER (
             PARTITION BY p.person_id

--- a/seeds/vocabulary/_sources.yml
+++ b/seeds/vocabulary/_sources.yml
@@ -1,0 +1,34 @@
+seeds:
+  - name: concept_synonym_seed
+    config:
+      column_types:
+        concept_id: integer
+        concept_synonym_name: varchar(1000)
+        language_concept_id: integer
+  - name: source_to_concept_map_seed
+    config:
+      column_types:
+        source_code: varchar(50)
+        source_concept_id: integer
+        source_vocabulary_id: varchar(20)
+        source_code_description: varchar(255)
+        target_concept_id: integer
+        target_vocabulary_id: varchar(20)
+        valid_start_date: date
+        valid_end_date: date
+        invalid_reason: varchar(1)
+  - name: drug_strength_seed
+    config:
+      column_types:
+        drug_concept_id: integer
+        ingredient_concept_id: integer
+        amount_value: numeric
+        amount_unit_concept_id: integer
+        numerator_value: numeric
+        numerator_unit_concept_id: integer
+        denominator_value: numeric
+        denominator_unit_concept_id: integer
+        box_size: integer
+        valid_start_date: date
+        valid_end_date: date
+        invalid_reason: varchar


### PR DESCRIPTION
This PR fixes a handful of issues that cause postgres to fail running the project.

These issues were all around type casting, given the empty seed files would result to everything being cast as integrers, and nulls without types being treated as text types. Duckdb is much more forgiving!

For now I have:
 - Added explicit seed types as needed (only on files where the seed is blank)
 - Explicitly cast `NULL`s to `INTEGER` types for ids