### PR TITLE
feat: Add workflow to generate DBT documentation and deploy to GitHub Pages

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,66 @@
+name: Generate DBT Docs
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - macros/**
+      - models/**
+      - seeds/**
+      - snapshots/**
+      - tests/**
+      - dbt_project.yml
+
+jobs:
+    update-docs:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                python-version: '3.12'
+                cache: 'pip'
+                cache-dependency-path: 'requirements/duckdb.txt'
+            - name: Install dependencies
+              run: |
+                pip install -r requirements/duckdb.txt
+            - name: Setup profile
+              run: |
+                cat << EOF > profiles.yml
+                synthea_omop_etl:
+                  outputs:
+                    dev:
+                      type: duckdb
+                      path: synthea_omop_etl.duckdb
+                      schema: dbt_synthea_dev
+                  target: dev
+                target: dev
+                EOF
+            - run: dbt deps
+            - name: Generate Docs and prepare for upload
+              run: |
+                  dbt docs generate
+                  mkdir ./payload
+                  mv ./target/index.html ./payload
+                  mv ./target/manifest.json ./payload
+                  mv ./target/catalog.json ./payload
+          
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                path: ./payload
+
+    deploy:
+        needs: update-docs
+        permissions:
+            pages: write      # to deploy to Pages
+            id-token: write   # required for OIDC token fetch
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR adds automatic dbt docs generation for the `dbt-synthea` project.

## Why bother?

The docs are a nice place to start for those not used to either dbt / OMOP to explore the models/DAG/etc (IMHO - feel free to disagree!); is easier for us to point people to our project!

This approach requires little/no effort of maintainers once setup.

## How does it work

 - runs when a relevant file in github has been modified in the main branch (as per paths filter)
 - installs python + requirements (caches as possible)
 - uses duckdb rendering of the project (lighterweight/friendly flavour of sql compared to others)
 - uploads to GitHub pages (this needs to be enabled by an admin)

## Next steps

 - Enable pages (if approved/agreed as useful)
 - Add other docs to make prettier/complete - e.g. an [overview](https://docs.getdbt.com/docs/build/documentation#setting-a-custom-overview) page, etc.
