### PR TITLE
refactor: use `datediff`/`dateadd` macro

### DIFF
--- a/models/omop/drug_era.sql
+++ b/models/omop/drug_era.sql
@@ -12,10 +12,10 @@ WITH ctePreDrugTarget AS (
         , COALESCE(
             NULLIF(drug_exposure_end_date, NULL)
             , NULLIF(
-                drug_exposure_start_date + days_supply * INTERVAL '1 day'
+                {{ dateadd("day", "days_supply", "drug_exposure_start_date") }}
                 , drug_exposure_start_date
             )
-            , drug_exposure_start_date + INTERVAL '1 day'
+            , {{ dateadd("day", 1, "drug_exposure_start_date") }}
         ) AS drug_exposure_end_date
     FROM {{ ref ('drug_exposure') }} AS d
     INNER JOIN {{ ref ('stg_vocabulary__concept_ancestor') }} AS ca

--- a/models/omop/drug_era.sql
+++ b/models/omop/drug_era.sql
@@ -122,9 +122,7 @@ WITH ctePreDrugTarget AS (
         , drug_sub_exposure_start_date
         , drug_sub_exposure_end_date
         , drug_exposure_count
-        , EXTRACT(
-            DAY FROM drug_sub_exposure_end_date - drug_sub_exposure_start_date
-        ) AS days_exposed
+        , {{ dbt.datediff("drug_sub_exposure_start_date", "drug_sub_exposure_end_date", "day") }} AS days_exposed
     FROM cteSubExposures
 )
 

--- a/models/omop/drug_era.sql
+++ b/models/omop/drug_era.sql
@@ -12,10 +12,10 @@ WITH ctePreDrugTarget AS (
         , COALESCE(
             NULLIF(drug_exposure_end_date, NULL)
             , NULLIF(
-                {{ dateadd("day", "days_supply", "drug_exposure_start_date") }}
+                {{ dbt.dateadd("day", "days_supply", "drug_exposure_start_date") }}
                 , drug_exposure_start_date
             )
-            , {{ dateadd("day", 1, "drug_exposure_start_date") }}
+            , {{ dbt.dateadd("day", 1, "drug_exposure_start_date") }}
         ) AS drug_exposure_end_date
     FROM {{ ref ('drug_exposure') }} AS d
     INNER JOIN {{ ref ('stg_vocabulary__concept_ancestor') }} AS ca


### PR DESCRIPTION
 - various sql engines do not allow interval extraction from delta (as deltas are passed as numeric types); concretely: snowflake, likely others
 - use the dbt standard datediff/dateadd macro to open up possibility to other sql engines
 - arguably more idiomatic
 - bring in line with other recent changes by @katy-sadowski