### PR TITLE
fix: build project prior to `dbt docs generate`

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -38,6 +38,9 @@ jobs:
                 target: dev
                 EOF
             - run: dbt deps
+            - run: dbt seed
+            - run: dbt run
+            - run: dbt test
             - name: Generate Docs and prepare for upload
               run: |
                   dbt docs generate


### PR DESCRIPTION
- causes dbt docs to pickup materialised column data types #75
 - arguably testing is over the top but duckdb is so fast there is little downside!