### PR TITLE
refactor: use determinisitic provider id

### DIFF
--- a/models/omop/location.sql
+++ b/models/omop/location.sql
@@ -1,5 +1,5 @@
 SELECT
-    ROW_NUMBER() OVER () AS location_id
+    ROW_NUMBER() OVER (ORDER BY state_abbreviation, patient_city, patient_zip, p.patient_id) AS location_id
     , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS address_1
     , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS address_2
     , p.patient_city AS city

--- a/models/omop/provider.sql
+++ b/models/omop/provider.sql
@@ -1,5 +1,5 @@
 SELECT
-    row_number() OVER (ORDER BY (SELECT null)) AS provider_id
+    row_number() OVER (ORDER BY provider_state, provider_city, provider_zip, provider_id) AS provider_id
     , provider_name
     , {{ dbt.cast("null", api.Column.translate_type("varchar(20)")) }} AS npi
     , {{ dbt.cast("null", api.Column.translate_type("varchar(20)")) }} AS dea


### PR DESCRIPTION
This PR cleans up code imported from upstream OHDSI/SyntheaETL SQL code, where models can produce non-deterministic output for `location` and `provider` tables.

For both tables, output is now ordered by:
 - state
 - city
 - zip
 - patient/provider id

Perhaps this is too complicated, open to other ideas! I think this is somewhat more logical than doing: `city > state > zip > _id`, but may not be correct to US-centric norms