### PR TITLE
refactor: build location model properly using patient and organization as a source

### DIFF
--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -1,0 +1,7 @@
+macros:
+  - name: safe_hash
+    description: This macro allows concatenation and hashing of fields that may contain `NULL` elements. For example, fields in an address.
+    arguments:
+      - name: columns
+        type: list[str]
+        description: A list of column names

--- a/macros/safe_hash.sql
+++ b/macros/safe_hash.sql
@@ -1,7 +1,7 @@
 {%- macro safe_hash(columns) -%}
 {% set coalesced_columns = [] %}
 {%- for column in columns -%}
-  {% do coalesced_columns.append("COALESCE(" + column + ", '')") %}
+  {% do coalesced_columns.append("COALESCE(" ~ column ~ ", '')") %}
 {%- endfor -%}
   MD5(
     {{ dbt.concat(coalesced_columns) }}

--- a/macros/safe_hash.sql
+++ b/macros/safe_hash.sql
@@ -1,7 +1,7 @@
 {%- macro safe_hash(columns) -%}
 {% set coalesced_columns = [] %}
 {%- for column in columns -%}
-  {% do coalesced_columns.append("COALESCE(" ~ column ~ ", '')") %}
+  {% do coalesced_columns.append("COALESCE(" ~ column.lower() ~ ", '')") %}
 {%- endfor -%}
   MD5(
     {{ dbt.concat(coalesced_columns) }}

--- a/macros/safe_hash.sql
+++ b/macros/safe_hash.sql
@@ -1,0 +1,9 @@
+{%- macro safe_hash(columns) -%}
+{% set coalesced_columns = [] %}
+{%- for column in columns -%}
+  {% do coalesced_columns.append("COALESCE(" + column + ", '')") %}
+{%- endfor -%}
+  MD5(
+    {{ dbt.concat(coalesced_columns) }}
+  )
+{%- endmacro -%}

--- a/models/intermediate/int__locations.sql
+++ b/models/intermediate/int__locations.sql
@@ -1,0 +1,59 @@
+{% set address_columns = [
+    "address_1", 
+    "address_2",
+    "city",
+    "state",
+    "zip",
+    "county"
+    ]
+%}
+
+WITH unioned_location_sources AS (
+    SELECT DISTINCT
+        p.patient_address AS address_1
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS address_2
+        , p.patient_city AS city
+        , s.state_abbreviation AS state
+        , p.patient_zip AS zip
+        , p.patient_county AS county
+        , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS country_concept_id
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS country_source_value
+        , p.patient_latitude AS latitude
+        , p.patient_longitude AS longitude
+    FROM {{ ref("stg_synthea__patients") }} AS p
+    LEFT JOIN {{ ref('stg_map__states') }} AS s ON p.patient_state = s.state_name
+
+    UNION
+
+    SELECT DISTINCT
+        organization_address AS address_1
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS address_2
+        , organization_city AS city
+        , organization_state AS state
+        , organization_zip AS zip
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS county
+        , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS country_concept_id
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS country_source_value
+        , organization_latitude AS latitude
+        , organization_longitude AS longitude
+    FROM
+        {{ ref("stg_synthea__organizations") }}
+)
+
+SELECT
+    address_1
+    , address_2
+    , city
+    , state
+    , zip
+    , county
+    , md5(
+        {%- for col in address_columns -%}
+        coalesce({{col}}, '') {{ "|| " if not loop.last }}
+        {%- endfor -%}
+    ) AS location_source_value
+    , country_concept_id
+    , country_source_value
+    , latitude
+    , longitude
+FROM unioned_location_sources

--- a/models/intermediate/int__locations.sql
+++ b/models/intermediate/int__locations.sql
@@ -5,8 +5,7 @@
     "state",
     "zip",
     "county"
-    ]
-%}
+] %}
 
 WITH unioned_location_sources AS (
     SELECT DISTINCT
@@ -47,11 +46,7 @@ SELECT
     , state
     , zip
     , county
-    , md5(
-        {%- for col in address_columns -%}
-        coalesce({{col}}, '') {{ "|| " if not loop.last }}
-        {%- endfor -%}
-    ) AS location_source_value
+    , {{ safe_hash(address_columns) }} AS location_source_value
     , country_concept_id
     , country_source_value
     , latitude

--- a/models/intermediate/int__person.sql
+++ b/models/intermediate/int__person.sql
@@ -19,7 +19,7 @@ SELECT
         WHEN upper(p.ethnicity) = 'NONHISPANIC' THEN 38003564
         ELSE 0
     END AS ethnicity_concept_id
-    , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS location_id
+    , loc.location_id
     , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS provider_id
     , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS care_site_id
     , p.patient_id AS person_source_value
@@ -30,4 +30,8 @@ SELECT
     , p.ethnicity AS ethnicity_source_value
     , 0 AS ethnicity_source_concept_id
 FROM {{ ref('stg_synthea__patients') }} AS p
+LEFT JOIN {{ ref('location') }} loc
+    -- Address and city provides enough entropy to join on safely
+    ON (p.patient_address = loc.address_1 AND p.patient_city = loc.city)
+
 WHERE p.patient_gender IS NOT NULL

--- a/models/intermediate/int__person.sql
+++ b/models/intermediate/int__person.sql
@@ -40,7 +40,5 @@ SELECT
 FROM {{ ref('stg_synthea__patients') }} AS p
 LEFT JOIN {{ ref('stg_map__states') }} AS s ON p.patient_state = s.state_name
 LEFT JOIN {{ ref('location') }} AS loc
-    -- Address and city provides enough entropy to join on safely
     ON loc.location_source_value = {{ safe_hash(address_columns) }}
-
 WHERE p.patient_gender IS NOT NULL

--- a/models/omop/care_site.sql
+++ b/models/omop/care_site.sql
@@ -5,9 +5,12 @@ SELECT
     , loc.location_id
     , organization_id AS care_site_source_value
     , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS place_of_service_source_value
-FROM {{ ref('stg_synthea__organizations') }} org
-LEFT JOIN {{ ref('location') }} loc
+FROM {{ ref('stg_synthea__organizations') }}
+LEFT JOIN {{ ref('location') }} AS loc
     ON
-        org.organization_name = loc.address_1
-        AND org.organization_address = loc.address_2
-        AND org.organization_city = loc.city
+        loc.location_source_value = MD5(
+            COALESCE(organization_address, '')
+            || COALESCE(organization_city, '')
+            || COALESCE(organization_state, '')
+            || COALESCE(organization_zip, '')
+        )

--- a/models/omop/care_site.sql
+++ b/models/omop/care_site.sql
@@ -2,7 +2,12 @@ SELECT
     ROW_NUMBER() OVER (ORDER BY organization_id) AS care_site_id
     , organization_name AS care_site_name
     , 0 AS place_of_service_concept_id
-    , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS location_id
+    , loc.location_id
     , organization_id AS care_site_source_value
     , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS place_of_service_source_value
-FROM {{ ref('stg_synthea__organizations') }}
+FROM {{ ref('stg_synthea__organizations') }} org
+LEFT JOIN {{ ref('location') }} loc
+    ON
+        org.organization_name = loc.address_1
+        AND org.organization_address = loc.address_2
+        AND org.organization_city = loc.city

--- a/models/omop/care_site.sql
+++ b/models/omop/care_site.sql
@@ -1,3 +1,10 @@
+{% set address_columns = [
+    "organization_address",
+    "organization_city",
+    "organization_state",
+    "organization_zip",
+] %}
+
 SELECT
     ROW_NUMBER() OVER (ORDER BY organization_id) AS care_site_id
     , organization_name AS care_site_name
@@ -8,9 +15,4 @@ SELECT
 FROM {{ ref('stg_synthea__organizations') }}
 LEFT JOIN {{ ref('location') }} AS loc
     ON
-        loc.location_source_value = MD5(
-            COALESCE(organization_address, '')
-            || COALESCE(organization_city, '')
-            || COALESCE(organization_state, '')
-            || COALESCE(organization_zip, '')
-        )
+        loc.location_source_value = {{ safe_hash(address_columns) }}

--- a/models/omop/location.sql
+++ b/models/omop/location.sql
@@ -1,37 +1,3 @@
-WITH unioned_location_sources AS (
-    SELECT DISTINCT
-        p.patient_address AS address_1
-        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS address_2
-        , p.patient_city AS city
-        , s.state_abbreviation AS state
-        , p.patient_zip AS zip
-        , p.patient_county AS county
-        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS location_source_value
-        , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS country_concept_id
-        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS country_source_value
-        , p.patient_latitude AS latitude
-        , p.patient_longitude AS longitude
-    FROM {{ ref("stg_synthea__patients") }} AS p
-    LEFT JOIN {{ ref('stg_map__states') }} AS s ON p.patient_state = s.state_name
-
-    UNION
-
-    SELECT DISTINCT
-        organization_name AS address_1
-        , organization_address AS address_2
-        , organization_city AS city
-        , organization_state AS state
-        , organization_zip AS zip
-        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS county
-        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS location_source_value
-        , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS country_concept_id
-        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS country_source_value
-        , organization_latitude AS latitude
-        , organization_longitude AS longitude
-    FROM
-        {{ ref("stg_synthea__organizations") }}
-)
-
 SELECT
     row_number() OVER (ORDER BY state, city, address_1) AS location_id
     , address_1
@@ -45,4 +11,4 @@ SELECT
     , country_source_value
     , latitude
     , longitude
-FROM unioned_location_sources
+FROM {{ ref('int__locations') }}

--- a/models/omop/location.sql
+++ b/models/omop/location.sql
@@ -1,5 +1,5 @@
 SELECT
-    row_number() OVER (ORDER BY state, city, address_1) AS location_id
+    row_number() OVER (ORDER BY state, city, address_1, location_source_value) AS location_id
     , address_1
     , address_2
     , city

--- a/models/omop/location.sql
+++ b/models/omop/location.sql
@@ -1,15 +1,48 @@
+WITH unioned_location_sources AS (
+    SELECT DISTINCT
+        p.patient_address AS address_1
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS address_2
+        , p.patient_city AS city
+        , s.state_abbreviation AS state
+        , p.patient_zip AS zip
+        , p.patient_county AS county
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS location_source_value
+        , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS country_concept_id
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS country_source_value
+        , p.patient_latitude AS latitude
+        , p.patient_longitude AS longitude
+    FROM {{ ref("stg_synthea__patients") }} AS p
+    LEFT JOIN {{ ref('stg_map__states') }} AS s ON p.patient_state = s.state_name
+
+    UNION
+
+    SELECT DISTINCT
+        organization_name AS address_1
+        , organization_address AS address_2
+        , organization_city AS city
+        , organization_state AS state
+        , organization_zip AS zip
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS county
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS location_source_value
+        , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS country_concept_id
+        , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS country_source_value
+        , organization_latitude AS latitude
+        , organization_longitude AS longitude
+    FROM
+        {{ ref("stg_synthea__organizations") }}
+)
+
 SELECT
-    ROW_NUMBER() OVER () AS location_id
-    , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS address_1
-    , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS address_2
-    , p.patient_city AS city
-    , s.state_abbreviation AS state
-    , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS county
-    , p.patient_zip AS zip
-    , p.patient_zip AS location_source_value
-    , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS country_concept_id
-    , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS country_source_value
-    , {{ dbt.cast("null", api.Column.translate_type("decimal")) }} AS latitude
-    , {{ dbt.cast("null", api.Column.translate_type("decimal")) }} AS longitude
-FROM {{ ref('stg_synthea__patients') }} AS p
-LEFT JOIN {{ ref('stg_map__states') }} AS s ON p.patient_state = s.state_name
+    row_number() OVER (ORDER BY state, city, address_1) AS location_id
+    , address_1
+    , address_2
+    , city
+    , state
+    , zip
+    , county
+    , location_source_value
+    , country_concept_id
+    , country_source_value
+    , latitude
+    , longitude
+FROM unioned_location_sources


### PR DESCRIPTION
This PR refactors the existing location model to have a valid PK to allow referencing from the `patient` and `care_site` tables. Previously the `location` table was orphaned and had duplicate entries.

The new referencing works by using a variation of address and city as a natural key to join on from other models.

---

I have some ongoing thoughts/issues:

- [ ] Unsure how best to join patient/care_site to location. I was going to use address and ZIP - but not all patients have ZIP codes. This may not matter at the moment, but want a setup that won't lead to duplicate joins if someone was to have a lot more synthea data input
  - We might want to join on more to prevent this in the future  
- [ ] I've gone for the somewhat arbitrary ordering of row numbers [here](https://github.com/OHDSI/dbt-synthea/blob/47c7fd058680f38e2bb5858e28ec7c5f32b51c31/models/omop/location.sql#L36) which is done for neatness/organization but may not be best
- [ ] At the moment [all `care_site_types` are `0`](https://github.com/OHDSI/dbt-synthea/blob/47c7fd058680f38e2bb5858e28ec7c5f32b51c31/models/omop/care_site.sql#L4) and I think we can do better! Perhaps we can use some simple heuristics like presence of `PCP` to set this as [`38004247 | Ambulatory Primary Care Clinic / Center|`](https://athena.ohdsi.org/search-terms/terms/38004247), but likely too much for this PR/for now!
- [ ] I've pushed `location_source_value` back to being NULL - this should probably be a concatenation of the available fields

There may be a far slicker approach to this but this is the best I can see for now! Happy to hear other's thoughts