### PR TITLE
refactor: complete metadata for sources, remove unused yml column metadata 

### DIFF
--- a/models/staging/synthea/_synthea__models.yml
+++ b/models/staging/synthea/_synthea__models.yml
@@ -26,8 +26,6 @@ models:
       - name: patient_suffix
         data_type: text
         description: "Name suffix, such as PhD, MD, JD, etc."
-      - name: patient_maiden_name
-        data_type: text
       - name: marital_status
         description: "Marital Status. M is married, S is single. Currently no support for divorce (D) or widowing (W)."
         data_type: text
@@ -151,7 +149,7 @@ models:
         description: "Diagnosis code from SNOMED-CT that this care plan addresses."
       - name: careplan_reason_description
         data_type: text
-  
+
   - name: stg_synthea__claims_transactions
     description: Synthea claim transactions table
     columns:
@@ -179,7 +177,7 @@ models:
       - name: transaction_amount
         data_type: double precision
         description: "Dollar amount for a CHARGE or TRANSFERIN."
-      - name: transaction_method  
+      - name: transaction_method
         data_type: text
         description: "Payment made by CASH, CHECK, ECHECK, COPAY, SYSTEM (adjustments without payment), or CC (credit card)."
       - name: transaction_from_date
@@ -198,11 +196,11 @@ models:
       - name: procedure_code
         data_type: text
       - name: procedure_code_modifier_1
-        data_type: text 
-      - name: procedure_code_modifier_2  
+        data_type: text
+      - name: procedure_code_modifier_2
         data_type: text
       - name: claim_diagnosis_ref_1
-        data_type: double precision 
+        data_type: double precision
         description: "Number indicating which diagnosis code from the claim applies to this transaction, 1-8 are valid options."
       - name: claim_diagnosis_ref_2
         data_type: double precision
@@ -223,7 +221,7 @@ models:
       - name: per_unit_amount
         data_type: double precision
         description: "Cost per unit."
-      - name: transfer_out_id 
+      - name: transfer_out_id
         data_type: double precision
         description: "If the transaction is a TRANSFERIN, the Charge ID of the corresponding TRANSFEROUT row."
       - name: transfer_type
@@ -378,7 +376,7 @@ models:
       - name: claim_type_id_2
         data_type: integer
         description: "Type of claim: 1 is professional, 2 is institutional."
-  
+
   - name: stg_synthea__conditions
     description: Synthea conditions table
     columns:
@@ -402,7 +400,7 @@ models:
         data_type: text
       - name: condition_description
         data_type: text
-  
+
   - name: stg_synthea__devices
     description: Synthea devices table
     columns:
@@ -496,7 +494,7 @@ models:
         description: "Diagnosis code from SNOMED-CT, only if this encounter targeted a specific condition."
       - name: encounter_reason_description
         data_type: text
-  
+
   - name: stg_synthea__imaging_studies
     description: Synthea imaging studies table
     columns:
@@ -563,7 +561,7 @@ models:
       - name: immunization_base_cost
         data_type: double precision
         description: "The line item cost of the immunization."
-  
+
   - name: stg_synthea__medications
     description: Synthea medications table
     columns:
@@ -614,7 +612,7 @@ models:
         description: "Diagnosis code from SNOMED-CT specifying why this medication was prescribed."
       - name: medication_reason_description
         data_type: text
-  
+
   - name: stg_synthea__observations
     description: Synthea observations table
     columns:
@@ -748,12 +746,6 @@ models:
       - name: uncovered_encounters
         data_type: integer
         description: "The number of Encounters not paid for by this Payer, and paid out of pocket by patients."
-      - name: covered_medications
-        data_type: integer
-        description: "The number of Medications paid for by this Payer."
-      - name: uncovered_medications
-        data_type: integer
-        description: "The number of Medications not paid for by this Payer, and paid out of pocket by patients."
       - name: covered_procedures
         data_type: integer
         description: "The number of Procedures paid for by this Payer."
@@ -769,13 +761,7 @@ models:
       - name: unique_customers
         data_type: integer
         description: "The number of unique patients enrolled with this Payer during the entire simulation."
-      - name: avg_qols
-        data_type: double precision
-        description: "The average Quality of Life Scores (QOLS) for all patients enrolled with this Payer during the entire simulation."
-      - name: member_months
-        data_type: integer
-        description: "The total number of months that patients were enrolled with this Payer during the simulation and paid monthly premiums (if any)."
-      
+
   - name: stg_synthea__procedures
     description: Synthea procedures table
     columns:
@@ -846,7 +832,7 @@ models:
       - name: provider_utilization
         data_type: integer
         description: "The number of Encounters performed by this Provider."
-  
+
   - name: stg_synthea__supplies
     description: Synthea supplies table
     columns:
@@ -870,4 +856,3 @@ models:
         data_type: text
       - name: supply_quantity
         data_type: integer
-      

--- a/models/staging/synthea/_synthea__models.yml
+++ b/models/staging/synthea/_synthea__models.yml
@@ -763,6 +763,12 @@ models:
       - name: unique_customers
         data_type: integer
         description: "The number of unique patients enrolled with this Payer during the entire simulation."
+      - name: qols_avg
+        data_type: double precision
+        description: "The average Quality of Life Scores (QOLS) for all patients enrolled with this Payer during the entire simulation."
+      - name: payer_member_months
+        data_type: integer
+        description: "The total number of months that patients were enrolled with this Payer during the simulation and paid monthly premiums (if any)."
 
   - name: stg_synthea__procedures
     description: Synthea procedures table

--- a/models/staging/synthea/_synthea__models.yml
+++ b/models/staging/synthea/_synthea__models.yml
@@ -26,6 +26,8 @@ models:
       - name: patient_suffix
         data_type: text
         description: "Name suffix, such as PhD, MD, JD, etc."
+      - name: maiden_name
+        data_type: text
       - name: marital_status
         description: "Marital Status. M is married, S is single. Currently no support for divorce (D) or widowing (W)."
         data_type: text

--- a/seeds/synthea/_sources.yml
+++ b/seeds/synthea/_sources.yml
@@ -107,6 +107,7 @@ seeds:
         PATIENT: varchar
         ENCOUNTER: varchar
         CODE: varchar
+        DESCRIPTION: varchar
   - name: devices
     config:
       column_types:


### PR DESCRIPTION
- `conditions` >> DESCRIPTION column not declared
-  multiple columns declared in synthea staging models that are not used in dbt-synthea

Loosely related to #101 #98 