### PR TITLE
Fix column declaration and enhance regexp_like support for Snowflake

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,8 +1,8 @@
-name: 'synthea_omop_etl'
-version: '0.1.0'
+name: "synthea_omop_etl"
+version: "0.1.0"
 config-version: 2
 
-profile: 'synthea_omop_etl'
+profile: "synthea_omop_etl"
 
 asset-paths: ["assets"]
 docs-paths: ["docs"]
@@ -13,7 +13,7 @@ seed-paths: ["seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-clean-targets:         # directories to be removed by `dbt clean`
+clean-targets: # directories to be removed by `dbt clean`
   - "target"
 
 vars:
@@ -34,3 +34,4 @@ seeds:
     synthea:
       +enabled: true
       +schema: synthea_seeds
+    +quote_columns: true

--- a/macros/regexp_like.sql
+++ b/macros/regexp_like.sql
@@ -1,0 +1,11 @@
+{%- macro regexp_like(subject, pattern) -%}
+    {{ return(adapter.dispatch("regexp_like")(subject, pattern)) }}
+{%- endmacro -%}
+
+{% macro default__regexp_like(subject, pattern) %}
+    {{ subject }} ~ '{{ pattern }}'
+{% endmacro %}
+
+{% macro snowflake__regexp_like(subject, pattern) %}
+    regexp_like({{ subject }}, '{{ pattern }}')
+{% endmacro %}

--- a/models/omop/measurement.sql
+++ b/models/omop/measurement.sql
@@ -57,7 +57,7 @@ WITH snomed_measurements AS (
         , 32827 AS measurement_type_concept_id
         , 0 AS operator_concept_id
         , CASE
-            WHEN o.observation_value ~ '^[-+]?[0-9]+\.?[0-9]*$'
+            WHEN {{ regexp_like("o.observation_value", "^[-+]?[0-9]+\.?[0-9]*$") }}
                 THEN {{ dbt.cast("o.observation_value", api.Column.translate_type("decimal")) }}
             ELSE {{ dbt.cast("null", api.Column.translate_type("decimal")) }}
         END AS value_as_number

--- a/seeds/synthea/_sources.yml
+++ b/seeds/synthea/_sources.yml
@@ -20,7 +20,7 @@ seeds:
   - name: careplans
     config:
       column_types:
-        ID: varchar
+        Id: varchar
         START: date
         STOP: date
         PATIENT: varchar
@@ -32,7 +32,7 @@ seeds:
   - name: claims
     config:
       column_types:
-        ID: varchar
+        Id: varchar
         PATIENTID: varchar
         PROVIDERID: varchar
         PRIMARYPATIENTINSURANCEID: varchar
@@ -66,7 +66,7 @@ seeds:
   - name: claims_transactions
     config:
       column_types:
-        ID: varchar
+        Id: varchar
         CLAIMID: varchar
         CHARGEID: integer
         PATIENTID: varchar
@@ -121,7 +121,7 @@ seeds:
   - name: encounters
     config:
       column_types:
-        ID: varchar
+        Id: varchar
         START: timestamp
         STOP: timestamp
         PATIENT: varchar
@@ -139,7 +139,7 @@ seeds:
   - name: imaging_studies
     config:
       column_types:
-        ID: varchar
+        Id: varchar
         DATE: timestamp
         PATIENT: varchar
         ENCOUNTER: varchar
@@ -192,7 +192,7 @@ seeds:
   - name: organizations
     config:
       column_types:
-        ID: varchar
+        Id: varchar
         NAME: varchar
         ADDRESS: varchar
         CITY: varchar
@@ -206,7 +206,7 @@ seeds:
   - name: patients
     config:
       column_types:
-        ID: varchar
+        Id: varchar
         BIRTHDATE: date
         DEATHDATE: date
         SSN: varchar
@@ -245,7 +245,7 @@ seeds:
   - name: payers
     config:
       column_types:
-        ID: varchar
+        Id: varchar
         NAME: varchar
         ADDRESS: varchar
         CITY: varchar
@@ -281,7 +281,7 @@ seeds:
   - name: providers
     config:
       column_types:
-        ID: varchar
+        Id: varchar
         ORGANIZATION: varchar
         NAME: varchar
         GENDER: varchar


### PR DESCRIPTION
This PR adds support for snowflake as a backend through various steps.

 - Correct the declaration of the `Id` column across multiple seed files
 - Add a new `regexp_like` macro for Snowflake, and...
 - Refactor the measurement model to utilize this new macro. 
 - Enable quoting of columns for Snowflake compatibility.