### PR TITLE
fix: remove imaging_studies > imaging_id unique test

### DIFF
--- a/models/staging/synthea/_synthea__models.yml
+++ b/models/staging/synthea/_synthea__models.yml
@@ -502,8 +502,6 @@ models:
     columns:
       - name: imaging_id
         data_type: text
-        tests:
-          - unique
       - name: imaging_datetime
         data_type: datetime
       - name: patient_id


### PR DESCRIPTION
This test should be enforced in theory, but:
  - This model is not used downstream at all
  - Due to a bug in Synthea duplicate imaging studies are generated synthetichealth/synthea#1545

Relax until fixed if needed for future work.