### PR TITLE
Fix test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ data/
 *.duckdb
 .dbt/
 profiles.yml
+.vscode/mcp.json

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ file_dict=$(python3 scripts/python/get_csv_filepaths.py path/to/vocab/csvs)
 dbt run-operation load_data_duckdb --args "{file_dict: $file_dict, vocab_tables: true}"
 ```
 
- 8. Seed the location mapper and currently unused empty OMOP tables:
+ 8. Seed the location mapper:
 ```bash
-dbt seed --select states omop
+dbt seed --select states
 ```
 
  9. Build the OMOP tables:
@@ -144,9 +144,9 @@ dbt run-operation create_synthea_tables
 
  9. **[BYO DATA ONLY]** Use the technology/package of your choice to load the OMOP vocabulary and raw Synthea files into these newly-created tables. **NOTE only Synthea v3.0.0 is supported at this time.**
 
- 10. Seed the location mapper and currently unused empty OMOP tables:
+ 10. Seed the location mapper:
 ```bash
-dbt seed --select states omop
+dbt seed --select states
 ```
 
  11. Build the OMOP tables:

--- a/models/intermediate/int__encounters.sql
+++ b/models/intermediate/int__encounters.sql
@@ -1,0 +1,36 @@
+WITH cte_dupes AS (
+    /*
+    some encounter IDs are duplicated due to a bug in the Synthea data generation process.
+    we flag duplicates here in order to remove them from downstream modesl, as there is no way to determine which encounter among duplicates is referenced by a foreign key to the encounters table.
+    */
+    SELECT encounter_id AS dupe_encounter_id
+    FROM {{ ref( 'stg_synthea__encounters') }}
+    GROUP BY encounter_id
+    HAVING COUNT(*) > 1
+)
+
+SELECT
+    e.encounter_id
+    , e.encounter_start_datetime
+    , e.encounter_start_date
+    , e.encounter_stop_datetime
+    , e.encounter_stop_date
+    , p.person_id
+    , pr.provider_id
+    , e.payer_id
+    , e.encounter_class
+    , e.encounter_code
+    , e.encounter_description
+    , e.base_encounter_cost
+    , e.total_encounter_cost
+    , e.encounter_payer_coverage
+    , e.encounter_reason_code
+    , e.encounter_reason_description
+FROM {{ ref( 'stg_synthea__encounters') }} AS e
+LEFT JOIN cte_dupes
+    ON e.encounter_id = cte_dupes.dupe_encounter_id
+INNER JOIN {{ ref ('int__person') }} AS p
+    ON e.patient_id = p.person_source_value
+LEFT JOIN {{ ref ('int__provider') }} AS pr
+    ON e.provider_id = pr.provider_source_value
+WHERE cte_dupes.dupe_encounter_id IS NULL

--- a/models/intermediate/int__er_visits.sql
+++ b/models/intermediate/int__er_visits.sql
@@ -5,11 +5,11 @@ emergency visits
 SELECT
     encounter_id AS visit_id
     , encounter_id
-    , patient_id
+    , person_id
     , encounter_class AS visit_class
     , encounter_start_date AS visit_start_date
     , encounter_stop_date AS visit_end_date
-FROM {{ ref( 'stg_synthea__encounters') }}
+FROM {{ ref( 'int__encounters') }}
 WHERE encounter_class IN ('emergency', 'urgentcare')
 -- only include single-day visits
 AND encounter_start_date = encounter_stop_date

--- a/models/intermediate/int__ip_visits.sql
+++ b/models/intermediate/int__ip_visits.sql
@@ -8,44 +8,52 @@ WITH
 all_ip_encounters AS (
     SELECT
         encounter_id
-        , patient_id
+        , person_id
         , encounter_class
         , encounter_start_date
         , encounter_stop_date
-    FROM {{ ref( 'stg_synthea__encounters') }}
+    FROM {{ ref( 'int__encounters') }}
     WHERE
-        encounter_class = 'inpatient'
-        OR (encounter_class IN ('ambulatory', 'wellness', 'outpatient', 'emergency', 'urgentcare') AND encounter_start_date != encounter_stop_date)
+        (
+            encounter_class = 'inpatient'
+            OR (encounter_class IN ('ambulatory', 'wellness', 'outpatient', 'emergency', 'urgentcare') AND encounter_start_date != encounter_stop_date)
+        )
+        AND encounter_start_date <= encounter_stop_date
 )
 
 , cte_collapse_encounters AS (
+    /*
+    Per patient, go through all encounter dates in ascending order, assigning each row the highest start_ordinal yet seen. This will fill in the start_ordinal for each end date, using the start_ordinal of the closest previous start date. The start_ordinal for each start date will remain unchanged. This means that if one encounter starts “during” another, the end date of the previous encounter will be ranked above start date of that encounter.
+    overall_ord simply ranks all the rows for each patient in order of date (in case of tie, start dates are ranked above end dates, then by ascending start_ordinal).
+    */
     SELECT
-        patient_id
+        person_id
         , event_date
         , event_type
         , max(start_ordinal)
             OVER (
-                PARTITION BY patient_id
-                ORDER BY event_date, event_type ROWS UNBOUNDED PRECEDING
+                PARTITION BY person_id
+                ORDER BY event_date, event_type, start_ordinal ROWS UNBOUNDED PRECEDING
             )
         AS start_ordinal
         , row_number() OVER (
-            PARTITION BY patient_id
-            ORDER BY event_date, event_type
+            PARTITION BY person_id
+            ORDER BY event_date, event_type, start_ordinal
         ) AS overall_ord
     FROM (
+        -- per patient, rank all start dates in start_ordinal, then tack on all the end dates (+1 day), with a NULL start_ordinal
         SELECT
-            patient_id
+            person_id
             , encounter_start_date AS event_date
             , -1 AS event_type
             , row_number() OVER (
-                PARTITION BY patient_id
+                PARTITION BY person_id
                 ORDER BY encounter_start_date, encounter_stop_date
             ) AS start_ordinal
         FROM all_ip_encounters
         UNION ALL
         SELECT
-            patient_id
+            person_id
             , {{ dbt.dateadd(datepart="day", interval=1, from_date_or_timestamp="encounter_stop_date") }} AS event_date
             , 1 AS event_type
             , NULL AS start_ordinal
@@ -54,54 +62,80 @@ all_ip_encounters AS (
 )
 
 , cte_end_dates AS (
+    /*
+    Per patient, take dates where the overall rank = 2x the start date rank, and subtract one day from them. This indicates the final end date of a collapsed encounter.
+    */
     SELECT
-        patient_id
+        person_id
         , {{ dbt.dateadd(datepart="day", interval=-1, from_date_or_timestamp="event_date") }} AS end_date
     FROM cte_collapse_encounters
     WHERE (2 * start_ordinal - overall_ord = 0)
 )
 
 , cte_visit_ends AS (
+    /*
+    Now go back to the original table with all IP encounters, and join it to the end dates table - tack an end date onto all encounters whose start date is on or before that date.  Without aggregation this would create duplicate rows anytime there’s more than 1 collapsed visit, so we assign the minimum qualifying end date to each encounter.
+    */
     SELECT
-        min(a.encounter_id) OVER (PARTITION BY a.patient_id, a.encounter_start_date) AS encounter_id
-        , a.encounter_id AS original_encounter_id
-        , a.patient_id
+        a.encounter_id
+        , a.person_id
         , a.encounter_start_date
-        , min(e.end_date) OVER (PARTITION BY a.patient_id, a.encounter_start_date) AS visit_end_date
+        , min(e.end_date) AS visit_end_date
     FROM all_ip_encounters AS a
     INNER JOIN cte_end_dates AS e
         ON
-            a.patient_id = e.patient_id
+            a.person_id = e.person_id
             AND a.encounter_start_date <= e.end_date
+    GROUP BY a.encounter_id, a.person_id, a.encounter_start_date
 )
 
 , cte_visit_starts AS (
+    -- Then among encounters with the same end date, we choose the earliest possible start date
     SELECT
-        encounter_id
-        , patient_id
+        person_id
         , min(encounter_start_date) AS visit_start_date
         , visit_end_date
     FROM cte_visit_ends
-    GROUP BY encounter_id, patient_id, visit_end_date
+    GROUP BY person_id, visit_end_date
+)
+
+, cte_visit_ids AS (
+    -- Assign each collapsed visit a unique ID
+    SELECT
+        row_number() OVER (ORDER BY person_id, visit_start_date) AS visit_id
+        , person_id
+        , visit_start_date
+        , visit_end_date
+    FROM cte_visit_starts
+)
+
+, er_starts AS (
+    -- identify encounter start dates associated with ER/urgent care visits
+    SELECT DISTINCT
+        person_id
+        , encounter_start_date
+    FROM all_ip_encounters
+    WHERE encounter_class IN ('emergency', 'urgentcare')
 )
 
 SELECT
-    v.encounter_id AS visit_id
+    v.visit_id
     -- bring back the original encounter ID so we can keep track of all encounters that were rolled up into each IP visit
-    , ve.original_encounter_id AS encounter_id
-    , v.patient_id
+    , ve.encounter_id
+    , v.person_id
     , CASE
         -- if the stay began with an ER encounter, classify as ER+IP
-        WHEN er.patient_id IS NOT NULL THEN 'er+ip'
+        WHEN er.person_id IS NOT NULL THEN 'er+ip'
         ELSE 'inpatient'
     END AS visit_class
     , v.visit_start_date
     , v.visit_end_date
-FROM cte_visit_starts AS v
+FROM cte_visit_ids AS v
 INNER JOIN cte_visit_ends AS ve
-    ON v.encounter_id = ve.encounter_id
-LEFT JOIN all_ip_encounters AS er
     ON
-        v.patient_id = er.patient_id
+        v.person_id = ve.person_id
+        AND v.visit_end_date = ve.visit_end_date
+LEFT JOIN er_starts AS er
+    ON
+        v.person_id = er.person_id
         AND v.visit_start_date = er.encounter_start_date
-        AND er.encounter_class IN ('emergency', 'urgentcare')

--- a/models/intermediate/int__op_visits.sql
+++ b/models/intermediate/int__op_visits.sql
@@ -3,11 +3,11 @@
 SELECT
     encounter_id AS visit_id
     , encounter_id
-    , patient_id
+    , person_id
     , encounter_class AS visit_class
     , encounter_start_date AS visit_start_date
     , encounter_stop_date AS visit_end_date
-FROM {{ ref( 'stg_synthea__encounters') }}
+FROM {{ ref( 'int__encounters') }}
 WHERE encounter_class IN ('ambulatory', 'wellness', 'outpatient')
 -- only include single-day visits
 AND encounter_start_date = encounter_stop_date

--- a/models/intermediate/int__visit_detail.sql
+++ b/models/intermediate/int__visit_detail.sql
@@ -1,7 +1,7 @@
 SELECT
-    row_number() OVER (ORDER BY p.person_id) AS visit_detail_id
+    row_number() OVER (ORDER BY e.encounter_id) AS visit_detail_id
     , e.encounter_id
-    , p.person_id
+    , e.person_id
     , CASE
         WHEN lower(e.encounter_class) IN ('ambulatory', 'wellness', 'outpatient') THEN 9202
         WHEN lower(e.encounter_class) IN ('emergency', 'urgentcare') THEN 9203
@@ -13,7 +13,7 @@ SELECT
     , e.encounter_stop_date AS visit_detail_end_date
     , e.encounter_stop_datetime AS visit_detail_stop_datetime
     , 32827 AS visit_detail_type_concept_id
-    , pr.provider_id
+    , e.provider_id
     , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS care_site_id
     , 0 AS admitted_from_concept_id
     , 0 AS discharged_to_concept_id
@@ -29,9 +29,5 @@ SELECT
 FROM {{ ref( 'int__visits_encounters') }} AS ve
 INNER JOIN {{ ref ('int__visits') }} AS v
     ON ve.visit_id = v.visit_id
-INNER JOIN {{ ref ('stg_synthea__encounters') }} AS e
+INNER JOIN {{ ref ('int__encounters') }} AS e
     ON ve.encounter_id = e.encounter_id
-INNER JOIN {{ ref ('int__person') }} AS p
-    ON e.patient_id = p.person_source_value
-LEFT JOIN {{ ref ('int__provider') }} AS pr
-    ON e.provider_id = pr.provider_source_value

--- a/models/intermediate/int__visits.sql
+++ b/models/intermediate/int__visits.sql
@@ -1,11 +1,11 @@
 /*
-for IP visits, we rolled up many encounters into a single visit and assigned it an visit_id. the original IDs of the rolled-up encounters are stored in the encounter_id column. for OP/ER visits, the visit_id is the same as the encounter_id as no roll-up occurred. in this model we assign an integer ID based on the rolled-up visit_id, to use as the visit_occurrence_id.
+for IP visits, we rolled up many encounters into a single visit and assigned it a visit_id. for OP/ER visits, the visit_id is the same as the encounter_id as no roll-up occurred. in this model we assign an integer ID based on the rolled-up visit_id, to use as the visit_occurrence_id.
 */
 
 WITH all_visits AS (
     SELECT
         visit_id
-        , patient_id
+        , person_id
         , visit_class
         , visit_start_date
         , visit_end_date
@@ -16,7 +16,7 @@ WITH all_visits AS (
 
     SELECT DISTINCT
         visit_id
-        , patient_id
+        , person_id
         , visit_class
         , visit_start_date
         , visit_end_date
@@ -25,6 +25,6 @@ WITH all_visits AS (
 )
 
 SELECT
-    ROW_NUMBER() OVER (ORDER BY patient_id) AS visit_occurrence_id
+    ROW_NUMBER() OVER (ORDER BY person_id) AS visit_occurrence_id
     , *
 FROM all_visits

--- a/models/omop/death.sql
+++ b/models/omop/death.sql
@@ -6,14 +6,14 @@
 -- The reasoncode column is the SNOMED code for the condition that caused death.
 
 SELECT
-    p.person_id
+    e.person_id
     , e.encounter_start_date AS death_date
     , e.encounter_start_datetime AS death_datetime
     , 32817 AS death_type_concept_id
     , srctostdvm.target_concept_id AS cause_concept_id
     , e.encounter_reason_code AS cause_source_value
     , srctostdvm.source_concept_id AS cause_source_concept_id
-FROM {{ ref('stg_synthea__encounters') }} AS e
+FROM {{ ref('int__encounters') }} AS e
 INNER JOIN {{ ref('int__source_to_standard_vocab_map') }} AS srctostdvm
     ON
         e.encounter_reason_code = srctostdvm.source_code
@@ -23,6 +23,4 @@ INNER JOIN {{ ref('int__source_to_standard_vocab_map') }} AS srctostdvm
         AND srctostdvm.source_vocabulary_id = 'SNOMED'
         AND srctostdvm.target_standard_concept = 'S'
         AND srctostdvm.target_invalid_reason IS null
-INNER JOIN {{ ref('int__person') }} AS p
-    ON e.patient_id = p.person_source_value
 WHERE e.encounter_code = '308646001'

--- a/models/omop/visit_occurrence.sql
+++ b/models/omop/visit_occurrence.sql
@@ -1,27 +1,25 @@
 SELECT
-    v.visit_occurrence_id
-    , p.person_id
+    visit_occurrence_id
+    , person_id
     , CASE
-        WHEN lower(v.visit_class) = 'er+ip' THEN 262
-        WHEN lower(v.visit_class) IN ('ambulatory', 'wellness', 'outpatient') THEN 9202
-        WHEN lower(v.visit_class) IN ('emergency', 'urgentcare') THEN 9203
-        WHEN lower(v.visit_class) = 'inpatient' THEN 9201
+        WHEN lower(visit_class) = 'er+ip' THEN 262
+        WHEN lower(visit_class) IN ('ambulatory', 'wellness', 'outpatient') THEN 9202
+        WHEN lower(visit_class) IN ('emergency', 'urgentcare') THEN 9203
+        WHEN lower(visit_class) = 'inpatient' THEN 9201
         ELSE 0
     END AS visit_concept_id
-    , v.visit_start_date
+    , visit_start_date
     , {{ dbt.cast("NULL", api.Column.translate_type("timestamp")) }} AS visit_start_datetime
-    , v.visit_end_date
+    , visit_end_date
     , {{ dbt.cast("NULL", api.Column.translate_type("timestamp")) }} AS visit_end_datetime
     , 32827 AS visit_type_concept_id
-    , {{ dbt.cast("NULL", api.Column.translate_type("varchar")) }}  AS provider_id
+    , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS provider_id
     , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }}  AS care_site_id
-    , v.visit_class AS visit_source_value
+    , visit_class AS visit_source_value
     , 0 AS visit_source_concept_id
     , 0 AS admitted_from_concept_id
     , {{ dbt.cast("NULL", api.Column.translate_type("varchar")) }} AS admitted_from_source_value
     , 0 AS discharged_to_concept_id
     , {{ dbt.cast("NULL", api.Column.translate_type("varchar")) }} AS discharged_to_source_value
     , {{ dbt.cast("NULL", api.Column.translate_type("integer")) }} AS preceding_visit_occurrence_id
-FROM {{ ref( 'int__visits') }} AS v
-INNER JOIN {{ ref ('int__person') }} AS p
-    ON v.patient_id = p.person_source_value
+FROM {{ ref( 'int__visits') }}

--- a/models/staging/synthea/stg_synthea__encounters.sql
+++ b/models/staging/synthea/stg_synthea__encounters.sql
@@ -16,8 +16,9 @@ WITH cte_encounters_lower AS (
         id AS encounter_id
         , "start" AS encounter_start_datetime
         , {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }} AS encounter_start_date
-        , "stop" AS encounter_stop_datetime
-        , {{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }} AS encounter_stop_date
+        -- default to start date if stop date is null
+        , COALESCE("stop", encounter_start_datetime) AS encounter_stop_datetime
+        , COALESCE({{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }}, encounter_start_date) AS encounter_stop_date
         , patient AS patient_id
         , organization AS organization_id
         , provider AS provider_id


### PR DESCRIPTION
Fixes #118 and #119 

There were 2 separate issues leading to PK duplication in PROCEDURE_OCCURRENCE:

- Something was messed up in the inpatient visit rollup logic
- There are duplicated encounter IDs in the source Synthea tables (a known bug)

For the first, I did a deep review of the IP rollup logic and fixed some issues with it.  I left a lot of comments because until now I didn't fully understand what it was doing (this came from ETL-Synthea).  I figure my comments may help others who want to understand or need to debug.

For the second, my solution was to remove these encounters from the project altogether.  Since there are other Synthea tables with foreign keys to the encounters table, I think this is the only way to handle the issue - I think it's better to lose the data than to incorrectly assign an encounter to a different encounter/patient's procedure/diagnosis/etc.