### PR TITLE
Added typing to and refactored the four python scripts. See Description.

### DIFF
--- a/scripts/python/generate_dbt_yaml.py
+++ b/scripts/python/generate_dbt_yaml.py
@@ -121,7 +121,9 @@ def parse_cli_arguments() -> tuple[Path, Path]:
     if output_dir.exists():
         if not output_dir.is_dir():
             parser.exit(1, f"{args.output_dir} exists but is not a directory.")
-        if not args.overwrite and any(output_dir.glob("*.yaml")):
+        if not args.overwrite and (
+            any(output_dir.glob("*.yaml")) or any(output_dir.glob("*.yml"))
+        ):
             parser.exit(
                 1,
                 f"""Exiting because {args.output_dir} contains .yaml files.

--- a/scripts/python/generate_dbt_yaml.py
+++ b/scripts/python/generate_dbt_yaml.py
@@ -1,19 +1,43 @@
-# A script to generate dbt YAML files from the OMOP CDM documentation
-#
-# Requires `BeautifulSoup4` and `ruamel.yaml` to be installed
-# Get the OMOP CDM documentation with e.g.:
-#   `wget https://raw.githubusercontent.com/OHDSI/CommonDataModel/refs/heads/main/docs/cdm54.html`
+#!/usr/bin/env  -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [ "beautifulsoup4", "ruamel-yaml", "requests" ]
+# ///
+
+"""
+A script to generate dbt YAML files from the OMOP CDM documentation
+Requires `BeautifulSoup4`, `ruamel.yaml`, and `requests` to be installed.
+If you have uv installed this will be done automatically.
+
+If you make this file executable you should also be able to run it directly using
+just the file path/name and the output directory path. e.g:
+./generate_dbt_yaml.py <output_dir>
+
+CDM version used is CDM 5.4 which corresponds to the url below.
+https://raw.githubusercontent.com/OHDSI/CommonDataModel/refs/heads/main/docs/cdm54.html
+
+If you wish to use a different version, either pass the url in as the --source argument
+or download the html file and pass the path in as --source.
+For example using wget <url>.
+"""
 
 import argparse
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import ParseResult, urlparse
 
-from ruamel.yaml import YAML
+import requests
 from bs4 import BeautifulSoup
+from bs4._typing import _AtMostOneElement  # pyright: ignore[reportPrivateUsage]
+from bs4.element import NavigableString, Tag
+from ruamel.yaml import YAML
+
+default_source_url = "https://raw.githubusercontent.com/OHDSI/CommonDataModel/refs/heads/main/docs/cdm54.html"
 
 
 @dataclass
-class omop_documentation_container:
+class OmopDocumentationContainer:
     cdm_field: str
     user_guide: str
     etl_conventions: str
@@ -25,103 +49,214 @@ class omop_documentation_container:
     foreign_key_domain: str
 
 
-def table_handler(table) -> list[omop_documentation_container]:
+@dataclass
+class CliArgs:
+    """A dataclass to ensure correct typing of command line arguments"""
+
+    source: str = default_source_url
+    output_dir: Path = Path()
+
+
+def is_url(value: str) -> bool:
+    """Check if a string is a url."""
+    parsed: ParseResult = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def download_url_to_temp_file(url: str, output_dir: Path) -> Path:
+    """Download a URL to a .tmp file in the output directory and return the local Path."""
+    response = requests.get(url)
+    response.raise_for_status()  # raises if e.g. 404 or timeout
+
+    with tempfile.NamedTemporaryFile(
+        delete=False, dir=output_dir, suffix=".tmp"
+    ) as tmp_file:
+        _ = tmp_file.write(response.content)
+        return Path(tmp_file.name)
+
+
+def parse_cli_arguments() -> tuple[Path, Path]:
+    """
+    Parse command line arguments.
+
+    Returns:
+         CLIArgs DataClass containing cdm_html: str and output_dir: Path().
+    """
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        description="""
+        Generate dbt YAML files from the OMOP CDM documentation.
+        For example: python generate_dbt_yaml.py cdm54.html ./output
+        """
+    )
+
+    # Common data model url.
+    _ = parser.add_argument(
+        "--source",
+        type=str,
+        help='Path or url to source html. If none provided defaults to:\n"{default_source}"',
+    )
+
+    # Output Directory.
+    _ = parser.add_argument(
+        "output_dir", type=Path, help="Path to the output directory"
+    )
+
+    # Store paths in CLIArgs data class.
+    args: CliArgs = parser.parse_args(namespace=CliArgs())
+
+    if not args.output_dir.exists():
+        parser.exit(1, f"Directory {args.output_dir} does not exist")
+
+    if is_url(args.source):
+        try:
+            source_path = download_url_to_temp_file(args.source, args.output_dir)
+        except Exception as e:
+            parser.exit(1, f"Failed to download from {args.source}: {e}")
+    else:
+        source_path = Path(args.source)
+        if not source_path.exists():
+            parser.exit(1, f"Source file does not exist: {source_path}")
+
+    return source_path, args.output_dir
+
+
+def table_handler(table: Tag) -> list[OmopDocumentationContainer]:
     """
     Takes a table and returns a list of objects that represent the tables in the table.
     """
-    rows = table.find_all("tr")
+    rows: list[Tag] = [_ensure_tag(div) for div in table.find_all("tr")]
 
     return [row_handler(row) for row in rows]
 
 
-def row_handler(rows) -> omop_documentation_container:
+def row_handler(row: Tag) -> OmopDocumentationContainer:
     """
     Take each row from a table and handle it, resulting in a object that can neatly
     store how the CDM docs express each column.
     """
-    cells = rows.find_all("td")
+    cell_tags: list[Tag] = [_ensure_tag(cell) for cell in row.find_all("td")]
 
-    cells = {
-        "cdm_field": cells[0].text,
-        "user_guide": cells[1].text,
-        "etl_conventions": cells[2].text,
-        "datatype": cells[3].text,
-        "required": cells[4].text,
-        "primary_key": cells[5].text,
-        "foreign_key": cells[6].text,
-        "foreign_key_table": cells[7].text,
-        "foreign_key_domain": cells[8].text,
+    cells_raw: dict[str, str] = {
+        "cdm_field": cell_tags[0].get_text(),
+        "user_guide": cell_tags[1].get_text(),
+        "etl_conventions": cell_tags[2].get_text(),
+        "datatype": cell_tags[3].get_text(),
+        "required": cell_tags[4].get_text(),
+        "primary_key": cell_tags[5].get_text(),
+        "foreign_key": cell_tags[6].get_text(),
+        "foreign_key_table": cell_tags[7].get_text(),
+        "foreign_key_domain": cell_tags[8].get_text(),
     }
 
     # Remove dangling whitespace and newlines from parsed HTML
-    cells = {k: v.replace("\n", "").strip() for k, v in cells.items()}
+    cells_stripped: dict[str, str] = {
+        k: v.replace("\n", "").strip() for k, v in cells_raw.items()
+    }
 
-    # Handle booleans expressed as text
-    cells.update(
-        {
-            "primary_key": sentinel_to_bool(cells["primary_key"]),
-            "required": sentinel_to_bool(cells["required"]),
-            "foreign_key": sentinel_to_bool(cells["foreign_key"]),
-        }
+    # Convert sentinels to booleans. Assign values to omop_documentation_container DataClass.
+    return OmopDocumentationContainer(
+        cdm_field=cells_stripped["cdm_field"],
+        user_guide=cells_stripped["user_guide"],
+        etl_conventions=cells_stripped["etl_conventions"],
+        datatype=cells_stripped["datatype"],
+        required=sentinel_to_bool(cells_stripped["required"]),
+        primary_key=sentinel_to_bool(cells_stripped["primary_key"]),
+        foreign_key=sentinel_to_bool(cells_stripped["foreign_key"]),
+        foreign_key_table=cells_stripped["foreign_key_table"],
+        foreign_key_domain=cells_stripped["foreign_key_domain"],
     )
 
-    return omop_documentation_container(**cells)
 
-
-def sentinel_to_bool(text) -> bool:
+def sentinel_to_bool(text: str) -> bool:
     if text == "Yes":
         return True
     else:
         return False
 
 
-def extract_table_description(table_handle) -> str:
-    description = table_handle.find(
-        "p", string="Table Description"
-    ).next_sibling.next_sibling.text
+def create_table_dict(
+    table: str,
+    table_description: str,
+    parsed_table: list[OmopDocumentationContainer],
+) -> dict[
+    str,
+    list[dict[str, str | list[dict[str, str | list[str | dict[str, dict[str, str]]]]]]],
+]:
+    table_dict: dict[
+        str,
+        list[
+            dict[
+                str, str | list[dict[str, str | list[str | dict[str, dict[str, str]]]]]
+            ]
+        ],
+    ] = {
+        "models": [
+            {
+                "name": table,
+                "description": table_description,
+                "columns": [
+                    omop_docs_to_dbt_config(doc_container)
+                    for doc_container in parsed_table
+                ],
+            }
+        ]
+    }
+    return table_dict
+
+
+def extract_table_description(table_handle: Tag) -> str:
+    sibling_element: _AtMostOneElement = _ensure_tag(
+        table_handle.find("p", string="Table Description")
+    ).next_sibling
+    description_element: _AtMostOneElement = _ensure_navigable_string(
+        sibling_element
+    ).next_sibling
+    description: str = _ensure_tag(description_element).get_text()
 
     return description.replace("\n", " ")
 
 
-def omop_docs_to_dbt_config(obj: omop_documentation_container) -> dict:
+def omop_docs_to_dbt_config(
+    doc_container: OmopDocumentationContainer,
+) -> dict[str, str | list[str | dict[str, dict[str, str]]]]:
     """
     With an OMOP documentation object, we can use some simple string parsing/heuristic
     to create dbt test configs.
     """
-    column_config = {
-        "name": obj.cdm_field,
-        "description": obj.user_guide,
-        "data_type": obj.datatype,
+    column_config: dict[str, str | list[str | dict[str, dict[str, str]]]] = {
+        "name": doc_container.cdm_field,
+        "description": doc_container.user_guide,
+        "data_type": doc_container.datatype,
     }
 
-    # == Create Tests ==
-    tests: list = []
+    # Create Tests
+    tests: list[str | dict[str, dict[str, str]]] = []
 
-    if obj.required:
+    if doc_container.required:
         tests.append("not_null")
 
-    if obj.primary_key:
+    if doc_container.primary_key:
         tests.append("unique")
 
-    if obj.foreign_key:
-        if obj.foreign_key_domain == "":
+    if doc_container.foreign_key:
+        if doc_container.foreign_key_domain == "":
             # Handle simpler cases first, where a domain is not constrained
-            test = {
+            test: dict[str, dict[str, str]] = {
                 "relationships": {
-                    "to": f"ref('{obj.foreign_key_table.lower()}')",
-                    "field": f"{obj.foreign_key_table.lower()}_id",
+                    "to": f"ref('{doc_container.foreign_key_table.lower()}')",
+                    "field": f"{doc_container.foreign_key_table.lower()}_id",
                 }
             }
             tests.append(test)
 
         else:
             # Add constrained domain tests
-            specific_test = {
+            specific_test: dict[str, dict[str, str]] = {
                 "dbt_utils.relationships_where": {
-                    "to": f"ref('{obj.foreign_key_table.lower()}')",
-                    "field": f"{obj.foreign_key_table.lower()}_id",
-                    "from_condition": f"{obj.cdm_field} <> 0",
-                    "to_condition": f"domain_id = '{obj.foreign_key_domain}'",
+                    "to": f"ref('{doc_container.foreign_key_table.lower()}')",
+                    "field": f"{doc_container.foreign_key_table.lower()}_id",
+                    "from_condition": f"{doc_container.cdm_field} <> 0",
+                    "to_condition": f"domain_id = '{doc_container.foreign_key_domain}'",
                 }
             }
             tests.append(specific_test)
@@ -132,86 +267,104 @@ def omop_docs_to_dbt_config(obj: omop_documentation_container) -> dict:
     return column_config
 
 
-def extract_table_names(soup_obj: BeautifulSoup) -> list[str]:
+def _ensure_tag(element: _AtMostOneElement) -> Tag:
+    """
+    Ensures that the given element is a BeautifulSoup Tag.
+    If the element is not a Tag, raises a ValueError.
+    """
+    if isinstance(element, Tag):
+        return element
+    raise ValueError(
+        f"No Tag returned from BeautifulSoup query.\nReturn type is {type(element)}"
+    )
+
+
+def _ensure_navigable_string(element: _AtMostOneElement) -> NavigableString:
+    """
+    Ensures that the given element is a BeautifulSoup NavigableString.
+    If the element is not a NavigableString, raises a ValueError.
+    """
+    if isinstance(element, NavigableString):
+        return element
+    raise ValueError(
+        f"No NavigableString returned from BeautifulSoup query.\nReturn type is {type(element)}"
+    )
+
+
+def extract_omop_table_names(soup_obj: BeautifulSoup) -> list[str]:
     """
     Dynamically extract table names from the OMOP CDM documentation
     """
-    table_names = []
+    headers: list[Tag] = [
+        _ensure_tag(div)
+        for div in soup_obj.find_all(
+            "div", attrs={"class": "section level3 tabset tabset-pills"}
+        )
+    ]
 
-    for div in soup_obj.find_all(
-        "div", attrs={"class": "section level3 tabset tabset-pills"}
-    ):
-        table_names.append(div.find("h3").text)
+    table_names: list[str] = []
+    for div in headers:
+        if div.h3:
+            table_names.append(div.h3.get_text())
 
-    print(" [Note] Ignoring `cohort` and `cohort_definition` tables from documentation")
-    table_names.remove("cohort")
-    table_names.remove("cohort_definition")
-
-    return table_names
+    # Exclude unwanted tables
+    unwanted_tables: set[str] = {"cohort", "cohort_definition"}
+    filtered_table_names: list[str] = [
+        table for table in table_names if table not in unwanted_tables
+    ]
+    return filtered_table_names
 
 
 def main(
-    cdm_docs_path: Path,
+    source_path: Path,
     output_dir: Path,
 ) -> None:
     """
     Main loop to generate dbt YAML files from the OMOP CDM documentation
     """
-    with open(cdm_docs_path) as file_handle:
-        file = file_handle.read()
+    with open(source_path) as file_handle:
+        file: str = file_handle.read()
 
-    soup = BeautifulSoup(file, features="html.parser")
+    soup: BeautifulSoup = BeautifulSoup(file, features="html.parser")
 
-    tables = extract_table_names(soup)
-
+    tables: list[str] = extract_omop_table_names(soup)
     print(f" Found {len(tables)} tables in the OMOP CDM documentation")
 
     for table in tables:
         # For each table generate the desired dbt yaml
         # Get desired div with table
-        table_handle = soup.find("div", attrs={"id": table})
+        div_handle: Tag = _ensure_tag(soup.find("div", attrs={"id": table}))
 
-        tbody_handle = table_handle.find("table").find("tbody")
-        parsed_table = table_handler(tbody_handle)
-        table_description = extract_table_description(table_handle)
+        table_handle: Tag = _ensure_tag(div_handle.find("table"))
+        tbody_handle: Tag = _ensure_tag(table_handle.find("tbody"))
+        parsed_table: list[OmopDocumentationContainer] = table_handler(tbody_handle)
 
-        table_dict = {
-            "models": [
-                {
-                    "name": table,
-                    "description": table_description,
-                    "columns": [omop_docs_to_dbt_config(obj) for obj in parsed_table],
-                }
-            ]
-        }
+        table_description: str = extract_table_description(div_handle)
 
-        yaml = YAML()
-        yaml.indent(mapping=2, sequence=4, offset=2)
+        # TODO: Look at turning this structure into a dataclass or pydantic BaseModel class.
+        table_dict: dict[
+            str,
+            list[
+                dict[
+                    str,
+                    str | list[dict[str, str | list[str | dict[str, dict[str, str]]]]],
+                ]
+            ],
+        ] = create_table_dict(table, table_description, parsed_table)
+
+        yaml: YAML = YAML()
+        yaml.indent(mapping=2, sequence=4, offset=2)  # pyright: ignore[reportUnknownMemberType]
         yaml.width = 100
-        yaml.dump(table_dict, open(f"{output_dir}/{table}.yml", "w"))
+        yaml.dump(table_dict, open(f"{output_dir}/{table}.yml", "w"))  # pyright: ignore[reportUnknownMemberType]
+        yaml.allow_duplicate_keys
+
+        if source_path.suffix == ".tmp" and source_path.exists():
+            source_path.unlink()
 
     print(f" Exported to `{output_dir}`")
     print("  Done!")
 
 
-# == Handle arguments ==
-# Get cdm54.html from the OMOP CDM documentation, using args
-parser = argparse.ArgumentParser(
-    description="Generate dbt YAML files from the OMOP CDM documentation. For example: python generate_dbt_yaml.py cdm54.html ./output"
-)
-parser.add_argument(
-    "cdm_html", type=str, help="Path to the OMOP CDM documentation HTML"
-)
-parser.add_argument("output_dir", type=str, help="Path to the output directory")
-args = parser.parse_args()
-
-cdm_docs_path = Path(args.cdm_html)
-output_dir = Path(args.output_dir)
-
-if not cdm_docs_path.exists():
-    parser.error(f"File {cdm_docs_path} does not exist")
-
-if not output_dir.exists():
-    parser.error(f"Directory {output_dir} does not exist")
-
-main(cdm_docs_path, output_dir)
+if __name__ == "__main__":
+    source, output_dir = parse_cli_arguments()
+    main(source, output_dir)

--- a/scripts/python/generate_vocab_shard.py
+++ b/scripts/python/generate_vocab_shard.py
@@ -12,10 +12,19 @@ from pathlib import Path
 from typing import cast
 
 import duckdb
+from duckdb import DuckDBPyConnection
+from dataclasses import dataclass
+import argparse
 
-db_file: Path = Path("./data/synthea_omop_etl.duckdb").resolve()
-source_schema: str = "dbt_synthea_dev_full"
-target_schema: str = "vocab_shard"
+
+@dataclass
+class CliArgs:
+    """A dataclass to ensure correct typing of command line arguments"""
+
+    db_file: Path = Path()
+    source_schema: str = ""
+    target_schema: str = ""
+
 
 # Initialize table lists.
 vocab_tables: list[str] = [
@@ -51,57 +60,104 @@ non_vocab_tables: list[str] = [
     "visit_occurrence",
 ]
 
-# Create db connection and temporary cids table.
-conn: duckdb.DuckDBPyConnection = duckdb.connect(db_file)
-_ = conn.sql("CREATE TEMPORARY TABLE cids(concept_id INTEGER);")
+
+def parse_cli_arguments() -> CliArgs:
+    """Parse command line arguments."""
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        description="""Create a vocab tables for synthea/OMOP database filtered to only the needed codes."""
+    )
+
+    _ = parser.add_argument(
+        "db_file",
+        type=Path,
+        help="Path to your database file",
+    )
+    _ = parser.add_argument(
+        "source_schema",
+        type=str,
+        help="Source schema. Example: dbt_synthea_dev_full",
+    )
+    _ = parser.add_argument(
+        "target_schema", "-t", type=str, help="Target schema. Example: vocab_shard"
+    )
+
+    # Store paths in CLIArgs data class.
+    args: CliArgs = parser.parse_args(namespace=CliArgs())
+
+    if args.db_file.resolve().exists():
+        if not args.db_file.is_file():
+            parser.exit(1, f"{args.db_file} is not a file.")
+    else:
+        parser.exit(1, f"{args.db_file} does not exist.")
+
+    return args
+
 
 # TODO: add unit concepts found in drug_strength table.
+def collate_concept_ids(conn: DuckDBPyConnection, args: CliArgs) -> None:
+    """Read non-vocab tables and collate concept ids into cids table."""
+    _ = conn.sql("CREATE TEMPORARY TABLE cids(concept_id INTEGER);")
 
-# Read non-vocab tables and collate concept ids into cids table.
-for table in non_vocab_tables:
-    print(f"Searching table {table}")
-    sql_non_vocab = f'SELECT "name" FROM pragma_table_info({source_schema}.{table}) WHERE "name" LIKE \'%_concept_id\';'
-    field_tuples: list[tuple[str]] = cast(
-        "list[tuple[str]]", conn.sql(sql_non_vocab).fetchall()
-    )
-    non_vocab_fields: list[str] = [field for (field,) in field_tuples]
-    for field in non_vocab_fields:
-        print(f"Searching field {field}")
-        concept_ids = conn.sql(f"SELECT DISTINCT {field} FROM {source_schema}.{table};")
-        concept_ids.insert_into("cids")
+    for table in non_vocab_tables:
+        print(f"Searching table {table}")
+        sql_non_vocab: str = f'SELECT "name" FROM pragma_table_info({args.source_schema}.{table}) WHERE "name" LIKE \'%_concept_id\';'
+        field_tuples: list[tuple[str]] = cast(
+            "list[tuple[str]]", conn.sql(sql_non_vocab).fetchall()
+        )
+        non_vocab_fields: list[str] = [field for (field,) in field_tuples]
+        for field in non_vocab_fields:
+            print(f"Searching field {field}")
+            concept_ids = conn.sql(
+                f"SELECT DISTINCT {field} FROM {args.source_schema}.{table};"
+            )
+            concept_ids.insert_into("cids")
 
 
-# Expand with all parents
-sql_ancestor: str = f"""SELECT DISTINCT ancestor_concept_id 
-FROM {source_schema}.concept_ancestor 
-INNER JOIN cids
-  ON descendant_concept_id = concept_id;"""
-expanded_ids = conn.sql(sql_ancestor)
-expanded_ids.insert_into("cids")
+def expand_concept_ids_with_parents(conn: DuckDBPyConnection, args: CliArgs) -> None:
+    """Expand concept ids (cids table) with all parents from source_schema"""
+    sql_ancestor: str = f"""SELECT DISTINCT ancestor_concept_id 
+    FROM {args.source_schema}.concept_ancestor 
+    INNER JOIN cids
+    ON descendant_concept_id = concept_id;"""
+    expanded_ids = conn.sql(sql_ancestor)
+    expanded_ids.insert_into("cids")
 
-# Filter vocab tables
-_ = conn.sql(f"CREATE SCHEMA IF NOT EXISTS {target_schema}")
-for table in vocab_tables:
-    print(f"Filtering table {table}")
-    _ = conn.sql(f"DROP TABLE IF EXISTS {target_schema}.{table};")
-    vocab_fields_tuples: list[str] = cast(
-        "list[str]",
-        conn.sql(
-            f'SELECT "name" from pragma_table_info({source_schema}.{table}) WHERE "name" LIKE \'concept_id\';'
-        ).fetchall(),
-    )
-    vocab_fields: list[str] = [field for field in vocab_fields_tuples]
-    sql_vocab: str = f"CREATE TABLE {target_schema}.{table} AS SELECT * FROM {source_schema}.{table} WHERE "
-    sql_vocab += " AND ".join(
-        [f"{field} IN (SELECT concept_id FROM cids)" for field in vocab_fields]
-    )
-    _ = conn.sql(sql_vocab)
 
-# Create non-filtered vocab tables.
-for table in vocab_tables_preserve:
-    print(f"Migrating table {table}")
-    _ = conn.sql(f"DROP TABLE IF EXISTS {target_schema}.{table};")
-    sql_vocab = f"CREATE TABLE {target_schema}.{table} AS SELECT * FROM {source_schema}.{table} "
-    _ = conn.sql(sql_vocab)
+def create_filtered_vocab_tables(conn: DuckDBPyConnection, args: CliArgs) -> None:
+    _ = conn.sql(f"CREATE SCHEMA IF NOT EXISTS {args.target_schema}")
+    for table in vocab_tables:
+        print(f"Filtering table {table}")
+        _ = conn.sql(f"DROP TABLE IF EXISTS {args.target_schema}.{table};")
+        vocab_fields_tuples: list[tuple[str]] = conn.sql(
+            f'SELECT "name" from pragma_table_info({args.source_schema}.{table}) WHERE "name" LIKE \'%concept_id%\';'
+        ).fetchall()
+        vocab_fields: list[str] = [field for (field,) in vocab_fields_tuples]
+        sql_vocab: str = f"CREATE TABLE {args.target_schema}.{table} AS SELECT * FROM {args.source_schema}.{table} WHERE "
+        sql_vocab += " AND ".join(
+            [f"{field} IN (SELECT concept_id FROM cids)" for field in vocab_fields]
+        )
+        _ = conn.sql(sql_vocab)
 
-conn.close()
+
+def create_non_filtered_vocab_tables(conn: DuckDBPyConnection, args: CliArgs) -> None:
+    for table in vocab_tables_preserve:
+        print(f"Migrating table {table}")
+        _ = conn.sql(f"DROP TABLE IF EXISTS {args.target_schema}.{table};")
+        sql_vocab = f"CREATE TABLE {args.target_schema}.{table} AS SELECT * FROM {args.source_schema}.{table} "
+        _ = conn.sql(sql_vocab)
+
+
+def main() -> None:
+    # Parse args.
+    args: CliArgs = parse_cli_arguments()
+
+    # Create duckdb connection and generate vocab tables.
+    with duckdb.connect(args.db_file) as conn:
+        collate_concept_ids(conn, args)
+        expand_concept_ids_with_parents(conn, args)
+        create_filtered_vocab_tables(conn, args)
+        create_non_filtered_vocab_tables(conn, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/python/generate_vocab_shard.py
+++ b/scripts/python/generate_vocab_shard.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env  -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [ duckdb ]
+# ///
+
 # used to generate seed vocabulary subset
 # this script filters the OMOP vocabulary tables to only include concepts found in a CDM
 # taken from https://github.com/OHDSI/Tutorial-Hades/blob/main/extras/FilterVocabulary.R

--- a/scripts/python/generate_vocab_shard.py
+++ b/scripts/python/generate_vocab_shard.py
@@ -1,67 +1,101 @@
 # used to generate seed vocabulary subset
 # this script filters the OMOP vocabulary tables to only include concepts found in a CDM
-# taken from https://github.com/OHDSI/Tutorial-Hades/blob/main/extras/FilterVocabulary.R 
+# taken from https://github.com/OHDSI/Tutorial-Hades/blob/main/extras/FilterVocabulary.R
+
+from pathlib import Path
+from typing import cast
 
 import duckdb
-import os
 
-db_file = os.path.expanduser("./data/synthea_omop_etl.duckdb")
-source_schema = "dbt_synthea_dev_full"
-target_schema = "vocab_shard"
+db_file: Path = Path("./data/synthea_omop_etl.duckdb").resolve()
+source_schema: str = "dbt_synthea_dev_full"
+target_schema: str = "vocab_shard"
 
+# Initialize table lists.
+vocab_tables: list[str] = [
+    "concept",
+    "concept_ancestor",
+    "concept_relationship",
+    "concept_synonym",
+    "drug_strength",
+]
+vocab_tables_preserve: list[str] = [
+    "concept_class",
+    "domain",
+    "relationship",
+    "vocabulary",
+]
+non_vocab_tables: list[str] = [
+    "condition_occurrence",
+    "cdm_source",
+    "condition_era",
+    "cost",
+    "death",
+    "device_exposure",
+    "drug_era",
+    "drug_exposure",
+    "measurement",
+    "observation_period",
+    "observation",
+    "payer_plan_period",
+    "person",
+    "procedure_occurrence",
+    "provider",
+    "visit_detail",
+    "visit_occurrence",
+]
+
+# Create db connection and temporary cids table.
 conn: duckdb.DuckDBPyConnection = duckdb.connect(db_file)
+_ = conn.sql("CREATE TEMPORARY TABLE cids(concept_id INTEGER);")
 
-vocab_tables = ["concept", "concept_ancestor", "concept_relationship", "concept_synonym", "drug_strength"]
-vocab_tables_preserve = ["concept_class", "domain", "relationship", "vocabulary"]
-non_vocab_tables = ["condition_occurrence", "cdm_source", "condition_era", "cost", "death", "device_exposure",
-                    "drug_era", "drug_exposure", "measurement", "observation_period", "observation",
-                    "payer_plan_period", "person", "procedure_occurrence", "provider", "visit_detail",
-                    "visit_occurrence"]
-concept_ids = [] 
+# TODO: add unit concepts found in drug_strength table.
 
-# Todo: add unit concepts found in drug_strength table
+# Read non-vocab tables and collate concept ids into cids table.
 for table in non_vocab_tables:
     print(f"Searching table {table}")
-    fields = conn.sql(f"PRAGMA table_info({source_schema}.{table});").fetchall()
-    fields = [field[1] for field in fields if field[1].endswith('_concept_id')]
-    for field in fields:
-        print(f"- Searching field {field}")
-        sql = f"SELECT DISTINCT {field} FROM {source_schema}.{table};"
-        concept_ids.extend(conn.sql(sql).fetchall())
+    sql_non_vocab = f'SELECT "name" FROM pragma_table_info({source_schema}.{table}) WHERE "name" LIKE \'%_concept_id\';'
+    field_tuples: list[tuple[str]] = cast(
+        "list[tuple[str]]", conn.sql(sql_non_vocab).fetchall()
+    )
+    non_vocab_fields: list[str] = [field for (field,) in field_tuples]
+    for field in non_vocab_fields:
+        print(f"Searching field {field}")
+        concept_ids = conn.sql(f"SELECT DISTINCT {field} FROM {source_schema}.{table};")
+        concept_ids.insert_into("cids")
+
 
 # Expand with all parents
-conn.sql("CREATE TEMPORARY TABLE cids(concept_id INTEGER);")
-for concept_id in concept_ids:
-    if concept_id[0] is not None:
-        conn.sql(f"INSERT INTO cids(concept_id) VALUES ({concept_id[0]});")
-
-sql = f"""SELECT DISTINCT ancestor_concept_id 
+sql_ancestor: str = f"""SELECT DISTINCT ancestor_concept_id 
 FROM {source_schema}.concept_ancestor 
 INNER JOIN cids
   ON descendant_concept_id = concept_id;"""
-concept_ids.extend(conn.sql(sql).fetchall())
-concept_ids = list(set(concept_ids))
-
-# Filter data to selected concept IDs
-for concept_id in concept_ids:
-    if concept_id[0] is not None:
-        conn.sql(f"INSERT INTO cids(concept_id) VALUES ({concept_id[0]});")
+expanded_ids = conn.sql(sql_ancestor)
+expanded_ids.insert_into("cids")
 
 # Filter vocab tables
-conn.sql(f"CREATE SCHEMA IF NOT EXISTS {target_schema}")
+_ = conn.sql(f"CREATE SCHEMA IF NOT EXISTS {target_schema}")
 for table in vocab_tables:
     print(f"Filtering table {table}")
-    conn.sql(f"DROP TABLE IF EXISTS {target_schema}.{table};")
-    fields = conn.sql(f"PRAGMA table_info({source_schema}.{table});").fetchall()
-    fields = [field[1] for field in fields if 'concept_id' in field[1]]
-    sql = f"CREATE TABLE {target_schema}.{table} AS SELECT * FROM {source_schema}.{table} WHERE "
-    sql += " AND ".join([f"{field} IN (SELECT concept_id FROM cids)" for field in fields])
-    conn.sql(sql)
+    _ = conn.sql(f"DROP TABLE IF EXISTS {target_schema}.{table};")
+    vocab_fields_tuples: list[str] = cast(
+        "list[str]",
+        conn.sql(
+            f'SELECT "name" from pragma_table_info({source_schema}.{table}) WHERE "name" LIKE \'concept_id\';'
+        ).fetchall(),
+    )
+    vocab_fields: list[str] = [field for field in vocab_fields_tuples]
+    sql_vocab: str = f"CREATE TABLE {target_schema}.{table} AS SELECT * FROM {source_schema}.{table} WHERE "
+    sql_vocab += " AND ".join(
+        [f"{field} IN (SELECT concept_id FROM cids)" for field in vocab_fields]
+    )
+    _ = conn.sql(sql_vocab)
 
+# Create non-filtered vocab tables.
 for table in vocab_tables_preserve:
     print(f"Migrating table {table}")
-    conn.sql(f"DROP TABLE IF EXISTS {target_schema}.{table};")
-    sql = f"CREATE TABLE {target_schema}.{table} AS SELECT * FROM {source_schema}.{table} "
-    conn.sql(sql)
+    _ = conn.sql(f"DROP TABLE IF EXISTS {target_schema}.{table};")
+    sql_vocab = f"CREATE TABLE {target_schema}.{table} AS SELECT * FROM {source_schema}.{table} "
+    _ = conn.sql(sql_vocab)
 
 conn.close()

--- a/scripts/python/get_csv_filepaths.py
+++ b/scripts/python/get_csv_filepaths.py
@@ -1,19 +1,19 @@
 # get a list of all csv files in a directory and return a json object with the file names as keys and the file paths as values
 
-import os
 import json
 import sys
+from pathlib import Path
 
-directory = sys.argv[1]
+# Create a resolved path from passed in directory argument.
+directory: Path = Path(sys.argv[1]).resolve()
 
-files = os.listdir(directory)
-csv_files = [file for file in files if file.endswith('.csv')]
-file_names = [os.path.splitext(file)[0] for file in csv_files]
+# Create a list of csv file paths.
+csv_file_paths: list[Path] = [
+    path for path in directory.iterdir() if path.suffix == ".csv"
+]
 
-file_dict = {}
-for file in csv_files:
-    file_path = os.path.join(directory, file)
-    file_name = os.path.splitext(file)[0]
-    file_dict[file_name] = file_path
+# Create a dictionary of filename: path_string and print in JSON format.
+csv_file_dict: dict[str, str] = {path.stem: str(path) for path in csv_file_paths}
 
-print(json.dumps(file_dict))
+# Print dictionary as JSON.
+print(json.dumps(csv_file_dict))

--- a/scripts/python/get_csv_filepaths.py
+++ b/scripts/python/get_csv_filepaths.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env  -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+
 # get a list of all csv files in a directory and return a json object with the file names as keys and the file paths as values
 
 import json

--- a/scripts/python/shard_to_seeds.py
+++ b/scripts/python/shard_to_seeds.py
@@ -1,27 +1,35 @@
 # used to generate seed vocabulary subset
 # this script saves vocabulary subset tables from a duckdb as csvs
 
-import duckdb
-import os
+from pathlib import Path
+from typing import cast
 
-db_file = os.path.expanduser("./data/synthea_omop_etl.duckdb")
-output_dir = os.path.expanduser("./data")
-source_schema = "vocab_shard"
+import duckdb
+
+db_file: Path = Path("./data/synthea_omop_etl.duckdb").resolve()
+output_dir: Path = Path("./data").resolve()
+source_schema: str = "vocab_shard"
 
 conn: duckdb.DuckDBPyConnection = duckdb.connect(db_file)
 
-tables_query = f"""
+tables_query: str = f"""
     SELECT table_name
     FROM information_schema.tables
     WHERE table_schema = '{source_schema}'
     """
-    
-# Fetch all table names in the schema
-tables = conn.sql(tables_query).fetchall()
 
-# Iterate over each table and export to CSV
-for table in tables:
-    table_name = table[0]
-    csv_path = os.path.join(output_dir, f"{table_name}.csv")
-    result = conn.execute(f"COPY {source_schema}.{table_name} TO '{csv_path}' (HEADER, DELIMITER ',');")
+# Fetch all table names in schema. Cast as strings for type safety.
+raw_rows: list[tuple[str]] = cast(list[tuple[str]], conn.sql(tables_query).fetchall())
+
+# From the list of table names create a list of tuples containing table_name and csv_path.
+tables_names_and_paths: list[tuple[str, Path]] = [
+    (name, output_dir / f"{name}.csv") for (name,) in raw_rows
+]
+
+# Iterate over each table and export to CSV.
+for table_name, csv_path in tables_names_and_paths:
+    result = conn.execute(
+        f"COPY {source_schema}.{table_name} TO '{csv_path}' (HEADER, DELIMITER ',');"
+    )
     print(f"Table '{table_name}' exported to {csv_path}")
+

--- a/scripts/python/shard_to_seeds.py
+++ b/scripts/python/shard_to_seeds.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env  -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [ duckdb ]
+# ///
+
 # used to generate seed vocabulary subset
 # this script saves vocabulary subset tables from a duckdb as csvs
 
@@ -32,4 +38,3 @@ for table_name, csv_path in tables_names_and_paths:
         f"COPY {source_schema}.{table_name} TO '{csv_path}' (HEADER, DELIMITER ',');"
     )
     print(f"Table '{table_name}' exported to {csv_path}")
-


### PR DESCRIPTION
### get_csv_filepaths.py
- Changed from using os path and directory functions to using pathlib's Path.
- Added type checking.
- Moved some logic to list/dict comprehension. We can expand this again if you feel it just makes it more difficult to read.

### shard_to_seeds.py
- Again changed to using Path.
- Added typing.
- Cast and type return values from duckdb.
- Separated the list creation and csv creation steps.

### generate_vocab_shard.py
- Uses Path.
- Added type hints.
- Changed some of the SQL queries to keep the list processes inside duckdb. Previously we were requesting information, cleaning it, putting it into a list. Then adding that list back into a duckdb table. The new queries should do this within duckdb.

(duckdb build and building without using seeds ran after this change, and I was able to use this script on the resulting DB. But I think my data was from a newer version of Synthea so it may be worth double checking these SQL queries succeed on a verified data set.)

### generate_dbt_yaml.py
- Added type hints.
- Added Parse Cli arguments function to handle passed in arguments.
- Renamed some classes to use CapWords convention.
- Added _ensure_tag() and _ensure_navigable_string() helper functions to handle/check return objects from BS4. Slightly hacky here as they return as a _AtMostOneElement type, which is there internal placeholder for None | Tag | NavigableString. Helper functions ensure this is actually the correct type at runtime.
- Refactored some functions.
- cdm_html argument is now --source and is optional. It can be a url or a path. If not provided then the CDM 5.4 html will be downloaded and used as source.