### PR TITLE
Refactor: Use adapter.quote() for identifiers.

### DIFF
--- a/models/omop/metadata.sql
+++ b/models/omop/metadata.sql
@@ -2,7 +2,7 @@ SELECT
     {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS metadata_id
     , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS metadata_concept_id
     , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS metadata_type_concept_id
-    , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS "name"
+    , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS {{ adapter.quote("name") }}
     , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS value_as_string
     , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS value_as_concept_id
     , {{ dbt.cast("null", api.Column.translate_type("decimal")) }} AS value_as_number

--- a/models/omop/note_nlp.sql
+++ b/models/omop/note_nlp.sql
@@ -3,7 +3,7 @@ SELECT
     , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS note_id
     , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS section_concept_id
     , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS snippet
-    , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS "offset"
+    , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS {{ adapter.quote("offset") }}
     , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS lexical_variant
     , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS note_nlp_concept_id
     , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS note_nlp_source_concept_id

--- a/models/staging/synthea/stg_synthea__allergies.sql
+++ b/models/staging/synthea/stg_synthea__allergies.sql
@@ -13,14 +13,14 @@ WITH cte_allergies_lower AS (
 , cte_allergies_rename AS (
 
     SELECT
-        "start" AS allergy_start_date
-        , "stop" AS allergy_stop_date
+        {{ adapter.quote("start") }} AS allergy_start_date
+        , {{ adapter.quote("stop") }} AS allergy_stop_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS allergy_code
-        , "system" AS allergy_code_system
+        , {{ adapter.quote("system") }} AS allergy_code_system
         , description AS allergy_description
-        , "type" AS allergy_type
+        , {{ adapter.quote("type") }} AS allergy_type
         , category AS allergy_category
         , reaction1 AS reaction_1_code
         , description1 AS reaction_1_description

--- a/models/staging/synthea/stg_synthea__careplans.sql
+++ b/models/staging/synthea/stg_synthea__careplans.sql
@@ -14,8 +14,8 @@ WITH cte_careplans_lower AS (
 
     SELECT
         id AS careplan_id
-        , "start" AS careplan_start_date
-        , "stop" AS careplan_stop_date
+        , {{ adapter.quote("start") }} AS careplan_start_date
+        , {{ adapter.quote("stop") }} AS careplan_stop_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS careplan_code

--- a/models/staging/synthea/stg_synthea__claims_transactions.sql
+++ b/models/staging/synthea/stg_synthea__claims_transactions.sql
@@ -17,7 +17,7 @@ WITH cte_claims_transactions_lower AS (
         , claimid AS claim_id
         , chargeid AS charge_id
         , patientid AS patient_id
-        , "type" AS transaction_type
+        , {{ adapter.quote("type") }} AS transaction_type
         , {{ dbt.cast("amount", api.Column.translate_type("decimal")) }} AS transaction_amount
         , method AS transaction_method
         , fromdate AS transaction_from_date

--- a/models/staging/synthea/stg_synthea__conditions.sql
+++ b/models/staging/synthea/stg_synthea__conditions.sql
@@ -13,8 +13,8 @@ WITH cte_conditions_lower AS (
 , cte_conditions_rename AS (
 
     SELECT
-        "start" AS condition_start_date
-        , "stop" AS condition_stop_date
+        {{ adapter.quote("start") }} AS condition_start_date
+        , {{ adapter.quote("stop") }} AS condition_stop_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS condition_code

--- a/models/staging/synthea/stg_synthea__devices.sql
+++ b/models/staging/synthea/stg_synthea__devices.sql
@@ -13,9 +13,9 @@ WITH cte_devices_lower AS (
 , cte_devices_rename AS (
 
     SELECT
-        "start" AS device_start_datetime
+        {{ adapter.quote("start") }} AS device_start_datetime
         , {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }} AS device_start_date
-        , "stop" AS device_stop_datetime
+        , {{ adapter.quote("stop") }} AS device_stop_datetime
         , {{ dbt.cast(adapter.quote("stop"), api.Column.translate_type("date")) }} AS device_stop_date
         , patient AS patient_id
         , encounter AS encounter_id

--- a/models/staging/synthea/stg_synthea__devices.sql
+++ b/models/staging/synthea/stg_synthea__devices.sql
@@ -14,9 +14,9 @@ WITH cte_devices_lower AS (
 
     SELECT
         "start" AS device_start_datetime
-        , {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }} AS device_start_date
+        , {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }} AS device_start_date
         , "stop" AS device_stop_datetime
-        , {{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }} AS device_stop_date
+        , {{ dbt.cast(adapter.quote("stop"), api.Column.translate_type("date")) }} AS device_stop_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS device_code

--- a/models/staging/synthea/stg_synthea__encounters.sql
+++ b/models/staging/synthea/stg_synthea__encounters.sql
@@ -14,7 +14,7 @@ WITH cte_encounters_lower AS (
 
     SELECT
         id AS encounter_id
-        , "start" AS encounter_start_datetime
+        , {{ adapter.quote("start") }} AS encounter_start_datetime
         , {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }} AS encounter_start_date
         -- default to start date if stop date is null
         , COALESCE("stop", "start") AS encounter_stop_datetime

--- a/models/staging/synthea/stg_synthea__encounters.sql
+++ b/models/staging/synthea/stg_synthea__encounters.sql
@@ -15,12 +15,12 @@ WITH cte_encounters_lower AS (
     SELECT
         id AS encounter_id
         , "start" AS encounter_start_datetime
-        , {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }} AS encounter_start_date
+        , {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }} AS encounter_start_date
         -- default to start date if stop date is null
         , COALESCE("stop", "start") AS encounter_stop_datetime
         , COALESCE(
-            {{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }},
-            {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }}
+            {{ dbt.cast(adapter.quote("stop"), api.Column.translate_type("date")) }},
+            {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }}
         ) AS encounter_stop_date
         , patient AS patient_id
         , organization AS organization_id

--- a/models/staging/synthea/stg_synthea__encounters.sql
+++ b/models/staging/synthea/stg_synthea__encounters.sql
@@ -17,7 +17,7 @@ WITH cte_encounters_lower AS (
         , {{ adapter.quote("start") }} AS encounter_start_datetime
         , {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }} AS encounter_start_date
         -- default to start date if stop date is null
-        , COALESCE("stop", "start") AS encounter_stop_datetime
+        , COALESCE({{ adapter.quote("stop") }}, {{ adapter.quote("start") }}) AS encounter_stop_datetime
         , COALESCE(
             {{ dbt.cast(adapter.quote("stop"), api.Column.translate_type("date")) }},
             {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }}

--- a/models/staging/synthea/stg_synthea__imaging_studies.sql
+++ b/models/staging/synthea/stg_synthea__imaging_studies.sql
@@ -14,7 +14,7 @@ WITH cte_imaging_studies_lower AS (
 
     SELECT
         id AS imaging_id
-        , "date" AS imaging_datetime
+        , {{ adapter.quote("date") }} AS imaging_datetime
         , patient AS patient_id
         , encounter AS encounter_id
         , series_uid

--- a/models/staging/synthea/stg_synthea__immunizations.sql
+++ b/models/staging/synthea/stg_synthea__immunizations.sql
@@ -13,7 +13,7 @@ WITH cte_immunizations_lower AS (
 , cte_immunizations_rename AS (
 
     SELECT
-        "date" AS immunization_date
+        {{ adapter.quote("date") }} AS immunization_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS immunization_code

--- a/models/staging/synthea/stg_synthea__medications.sql
+++ b/models/staging/synthea/stg_synthea__medications.sql
@@ -13,9 +13,9 @@ WITH cte_medications_lower AS (
 , cte_medications_rename AS (
 
     SELECT
-        "start" AS medication_start_datetime
+        {{ adapter.quote("start") }} AS medication_start_datetime
         , {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }} AS medication_start_date
-        , "stop" AS medication_stop_datetime
+        , {{ adapter.quote("stop") }} AS medication_stop_datetime
         , {{ dbt.cast(adapter.quote("stop"), api.Column.translate_type("date")) }} AS medication_stop_date
         , patient AS patient_id
         , payer AS payer_id

--- a/models/staging/synthea/stg_synthea__medications.sql
+++ b/models/staging/synthea/stg_synthea__medications.sql
@@ -14,9 +14,9 @@ WITH cte_medications_lower AS (
 
     SELECT
         "start" AS medication_start_datetime
-        , {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }} AS medication_start_date
+        , {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }} AS medication_start_date
         , "stop" AS medication_stop_datetime
-        , {{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }} AS medication_stop_date
+        , {{ dbt.cast(adapter.quote("stop"), api.Column.translate_type("date")) }} AS medication_stop_date
         , patient AS patient_id
         , payer AS payer_id
         , encounter AS encounter_id

--- a/models/staging/synthea/stg_synthea__observations.sql
+++ b/models/staging/synthea/stg_synthea__observations.sql
@@ -13,16 +13,16 @@ WITH cte_observations_lower AS (
 , cte_observations_rename AS (
 
     SELECT
-        "date" AS observation_datetime
+        {{ adapter.quote("date") }} AS observation_datetime
         , {{ dbt.cast(adapter.quote("date"), api.Column.translate_type("date")) }} AS observation_date
         , patient AS patient_id
         , encounter AS encounter_id
         , category AS observation_category
         , code AS observation_code
         , description AS observation_description
-        , "value" AS observation_value
+        , {{ adapter.quote("value") }} AS observation_value
         , units AS observation_units
-        , "type" AS observation_value_type
+        , {{ adapter.quote("type") }} AS observation_value_type
     FROM cte_observations_lower
 
 )

--- a/models/staging/synthea/stg_synthea__observations.sql
+++ b/models/staging/synthea/stg_synthea__observations.sql
@@ -14,7 +14,7 @@ WITH cte_observations_lower AS (
 
     SELECT
         "date" AS observation_datetime
-        , {{ dbt.cast("\"date\"", api.Column.translate_type("date")) }} AS observation_date
+        , {{ dbt.cast(adapter.quote("date"), api.Column.translate_type("date")) }} AS observation_date
         , patient AS patient_id
         , encounter AS encounter_id
         , category AS observation_category

--- a/models/staging/synthea/stg_synthea__organizations.sql
+++ b/models/staging/synthea/stg_synthea__organizations.sql
@@ -14,7 +14,7 @@ WITH cte_organizations_lower AS (
 
     SELECT
         id AS organization_id
-        , "name" AS organization_name
+        , {{ adapter.quote("name") }} AS organization_name
         , address AS organization_address
         , city AS organization_city
         , state AS organization_state

--- a/models/staging/synthea/stg_synthea__patients.sql
+++ b/models/staging/synthea/stg_synthea__patients.sql
@@ -20,8 +20,8 @@ WITH cte_patients_lower AS (
         , drivers AS drivers_license_number
         , passport AS passport_number
         , prefix AS patient_prefix
-        , "first" AS patient_first_name
-        , "last" AS patient_last_name
+        , {{ adapter.quote("first") }} AS patient_first_name
+        , {{ adapter.quote("last") }} AS patient_last_name
         , suffix AS patient_suffix
         , maiden AS maiden_name
         , marital AS marital_status

--- a/models/staging/synthea/stg_synthea__payers.sql
+++ b/models/staging/synthea/stg_synthea__payers.sql
@@ -14,7 +14,7 @@ WITH cte_payers_lower AS (
 
     SELECT
         id AS payer_id
-        , "name" AS payer_name
+        , {{ adapter.quote("name") }} AS payer_name
         , city AS payer_city
         , state_headquartered AS payer_state_headquartered
         , zip AS payer_zip

--- a/models/staging/synthea/stg_synthea__procedures.sql
+++ b/models/staging/synthea/stg_synthea__procedures.sql
@@ -13,9 +13,9 @@ WITH cte_procedures_lower AS (
 , cte_procedures_rename AS (
 
     SELECT
-        "start" AS procedure_start_datetime
+        {{ adapter.quote("start") }} AS procedure_start_datetime
         , {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }} AS procedure_start_date
-        , "stop" AS procedure_stop_datetime
+        , {{ adapter.quote("stop") }} AS procedure_stop_datetime
         , {{ dbt.cast(adapter.quote("stop"), api.Column.translate_type("date")) }} AS procedure_stop_date
         , patient AS patient_id
         , encounter AS encounter_id

--- a/models/staging/synthea/stg_synthea__procedures.sql
+++ b/models/staging/synthea/stg_synthea__procedures.sql
@@ -14,9 +14,9 @@ WITH cte_procedures_lower AS (
 
     SELECT
         "start" AS procedure_start_datetime
-        , {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }} AS procedure_start_date
+        , {{ dbt.cast(adapter.quote("start"), api.Column.translate_type("date")) }} AS procedure_start_date
         , "stop" AS procedure_stop_datetime
-        , {{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }} AS procedure_stop_date
+        , {{ dbt.cast(adapter.quote("stop"), api.Column.translate_type("date")) }} AS procedure_stop_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS procedure_code

--- a/models/staging/synthea/stg_synthea__providers.sql
+++ b/models/staging/synthea/stg_synthea__providers.sql
@@ -15,7 +15,7 @@ WITH cte_providers_lower AS (
     SELECT
         id AS provider_id
         , organization AS organization_id
-        , "name" AS provider_name
+        , {{ adapter.quote("name") }} AS provider_name
         , gender AS provider_gender
         , speciality AS provider_specialty
         , address AS provider_address

--- a/models/staging/synthea/stg_synthea__supplies.sql
+++ b/models/staging/synthea/stg_synthea__supplies.sql
@@ -13,7 +13,7 @@ WITH cte_supplies_lower AS (
 , cte_supplies_rename AS (
 
     SELECT
-        "date" AS supply_date
+        {{ adapter.quote("date") }} AS supply_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS supply_code

--- a/seeds/synthea/_sources.yml
+++ b/seeds/synthea/_sources.yml
@@ -49,8 +49,8 @@ seeds:
         DIAGNOSIS8: varchar
         REFERRINGPROVIDERID: varchar
         APPOINTMENTID: varchar
-        CURRENTILLNESSDATE: timestamp
-        SERVICEDATE: timestamp
+        CURRENTILLNESSDATE: timestamptz
+        SERVICEDATE: timestamptz
         SUPERVISINGPROVIDERID: varchar
         STATUS1: varchar
         STATUS2: varchar
@@ -58,9 +58,9 @@ seeds:
         OUTSTANDING1: float
         OUTSTANDING2: float
         OUTSTANDINGP: float
-        LASTBILLEDDATE1: timestamp
-        LASTBILLEDDATE2: timestamp
-        LASTBILLEDDATEP: timestamp
+        LASTBILLEDDATE1: timestamptz
+        LASTBILLEDDATE2: timestamptz
+        LASTBILLEDDATEP: timestamptz
         HEALTHCARECLAIMTYPEID1: integer
         HEALTHCARECLAIMTYPEID2: integer
   - name: claims_transactions
@@ -73,8 +73,8 @@ seeds:
         TYPE: varchar
         AMOUNT: float
         METHOD: varchar
-        FROMDATE: timestamp
-        TODATE: timestamp
+        FROMDATE: timestamptz
+        TODATE: timestamptz
         PLACEOFSERVICE: varchar
         PROCEDURECODE: varchar
         MODIFIER1: varchar
@@ -111,8 +111,8 @@ seeds:
   - name: devices
     config:
       column_types:
-        START: timestamp
-        STOP: timestamp
+        START: timestamptz
+        STOP: timestamptz
         PATIENT: varchar
         ENCOUNTER: varchar
         CODE: varchar
@@ -122,8 +122,8 @@ seeds:
     config:
       column_types:
         Id: varchar
-        START: timestamp
-        STOP: timestamp
+        START: timestamptz
+        STOP: timestamptz
         PATIENT: varchar
         ORGANIZATION: varchar
         PROVIDER: varchar
@@ -140,7 +140,7 @@ seeds:
     config:
       column_types:
         Id: varchar
-        DATE: timestamp
+        DATE: timestamptz
         PATIENT: varchar
         ENCOUNTER: varchar
         SERIES_UID: varchar
@@ -155,7 +155,7 @@ seeds:
   - name: immunizations
     config:
       column_types:
-        DATE: timestamp
+        DATE: timestamptz
         PATIENT: varchar
         ENCOUNTER: varchar
         CODE: varchar
@@ -164,8 +164,8 @@ seeds:
   - name: medications
     config:
       column_types:
-        START: timestamp
-        STOP: timestamp
+        START: timestamptz
+        STOP: timestamptz
         PATIENT: varchar
         PAYER: varchar
         ENCOUNTER: varchar
@@ -180,7 +180,7 @@ seeds:
   - name: observations
     config:
       column_types:
-        DATE: timestamp
+        DATE: timestamptz
         PATIENT: varchar
         ENCOUNTER: varchar
         CATEGORY: varchar
@@ -236,8 +236,8 @@ seeds:
       column_types:
         PATIENT: varchar
         MEMBERID: varchar
-        START_YEAR: timestamp
-        END_YEAR: timestamp
+        START_YEAR: timestamptz
+        END_YEAR: timestamptz
         PAYER: varchar
         SECONDARY_PAYER: varchar
         OWNERSHIP: varchar
@@ -269,8 +269,8 @@ seeds:
   - name: procedures
     config:
       column_types:
-        START: timestamp
-        STOP: timestamp
+        START: timestamptz
+        STOP: timestamptz
         PATIENT: varchar
         ENCOUNTER: varchar
         CODE: varchar


### PR DESCRIPTION
Replaced hardcoded double quotes around SQL identifiers with `adapter.quote()` to improve cross-database compatibility in dbt models.

This change ensures that identifier quoting is handled correctly by the specific dbt adapter being used. Modified files primarily in `models/staging/synthea/` and `models/omop/` where identifiers were hard-quoted in `dbt.cast` calls or aliases.