### PR TITLE
Fix for duckdb 1.3

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -17,31 +17,31 @@ clean-targets: # directories to be removed by `dbt clean`
   - "target"
 
 vars:
-  seed_source: false
+  seed_source: true
 
 models:
   synthea_omop_etl:
     intermediate:
       +materialized: table
       +docs:
-        node_color: "#FBC511"
+        node_color: '#FBC511'
     omop:
       +materialized: table
       +docs:
-        node_color: "#EB6622"
+        node_color: '#EB6622'
     staging:
       synthea:
         +materialized: view
         +docs:
-          node_color: "#336B91"
+          node_color: '#336B91'
       vocabulary:
         +materialized: view
         +docs:
-          node_color: "#336B91"
+          node_color: '#336B91'
       map:
         +materialized: view
         +docs:
-          node_color: "#336B91"
+          node_color: '#336B91'
 
 seeds:
   +quote_columns: true
@@ -50,14 +50,14 @@ seeds:
       +enabled: true
       +schema: map_seeds
       +docs:
-        node_color: "#69AED5"
+        node_color: '#69AED5'
     vocabulary:
-      +enabled: false
+      +enabled: true
       +schema: vocab_seeds
       +docs:
-        node_color: "#69AED5"
+        node_color: '#69AED5'
     synthea:
-      +enabled: false
-      +schema: synthea_seeds
+      +enabled: true
+      +schema: synthea_seeds    
       +docs:
-        node_color: "#69AED5"
+        node_color: '#69AED5'

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -17,31 +17,31 @@ clean-targets: # directories to be removed by `dbt clean`
   - "target"
 
 vars:
-  seed_source: true
+  seed_source: false
 
 models:
   synthea_omop_etl:
     intermediate:
       +materialized: table
       +docs:
-        node_color: '#FBC511'
+        node_color: "#FBC511"
     omop:
       +materialized: table
       +docs:
-        node_color: '#EB6622'
+        node_color: "#EB6622"
     staging:
       synthea:
         +materialized: view
         +docs:
-          node_color: '#336B91'
+          node_color: "#336B91"
       vocabulary:
         +materialized: view
         +docs:
-          node_color: '#336B91'
+          node_color: "#336B91"
       map:
         +materialized: view
         +docs:
-          node_color: '#336B91'
+          node_color: "#336B91"
 
 seeds:
   +quote_columns: true
@@ -50,14 +50,14 @@ seeds:
       +enabled: true
       +schema: map_seeds
       +docs:
-        node_color: '#69AED5'
+        node_color: "#69AED5"
     vocabulary:
-      +enabled: true
+      +enabled: false
       +schema: vocab_seeds
       +docs:
-        node_color: '#69AED5'
+        node_color: "#69AED5"
     synthea:
-      +enabled: true
-      +schema: synthea_seeds    
+      +enabled: false
+      +schema: synthea_seeds
       +docs:
-        node_color: '#69AED5'
+        node_color: "#69AED5"

--- a/macros/timestamptz_to_naive.sql
+++ b/macros/timestamptz_to_naive.sql
@@ -1,0 +1,18 @@
+{% macro timestamptz_to_naive(column, target_tz=None) %}
+  {%- set target_tz = var("dbt_date:time_zone", "UTC") if target_tz is none else target_tz -%}
+  {{ adapter.dispatch('timestamptz_to_naive', 'dbt_date')(column, target_tz) }}
+{% endmacro %}
+
+{# 
+  Default implementation using `AT TIME ZONE`, 
+  which works in PostgreSQL, DuckDB, and Redshift. 
+  Converts a TIMESTAMPTZ to a naive TIMESTAMP in the target timezone.
+#}
+
+{% macro default__timestamptz_to_naive(column, target_tz) %}
+  {{ column }} AT TIME ZONE '{{ target_tz }}'
+{% endmacro %}
+
+{% macro snowflake__timestamptz_to_naive(column, target_tz) %}
+  CONVERT_TIMEZONE('{{ target_tz }}', {{ column }})::timestamp
+{% endmacro %}

--- a/models/omop/_models/cdm_source.yml
+++ b/models/omop/_models/cdm_source.yml
@@ -22,7 +22,7 @@ models:
         description: The description of the CDM instance.
         data_type: varchar(MAX)
       - name: source_documentation_reference
-        description: ''
+        description: Refers to a publication or web resource describing the source data
         data_type: varchar(255)
       - name: cdm_etl_reference
         description: ''

--- a/models/omop/_models/concept_ancestor.yml
+++ b/models/omop/_models/concept_ancestor.yml
@@ -2,12 +2,14 @@ models:
   - name: concept_ancestor
     description: The CONCEPT_ANCESTOR table is designed to simplify observational analysis by providing
       the complete hierarchical relationships between Concepts. Only direct parent-child relationships
-      between Concepts are stored in the CONCEPT_RELATIONSHIP table. To determine higher level ancestry
+      between Concepts are stored in the CONCEPT_RELATIONSHIP table. To determine higher-level ancestry
       connections, all individual direct relationships would have to be navigated at analysis time. The
       CONCEPT_ANCESTOR table includes records for all parent-child relationships, as well as grandparent-grandchild
-      relationships and those of any other level of lineage. Using the CONCEPT_ANCESTOR table allows for
-      querying for all descendants of a hierarchical concept. For example, drug ingredients and drug products
-      are all descendants of a drug class ancestor.
+      relationships and those of any other level of lineage for Standard or Classification concepts. Using
+      the CONCEPT_ANCESTOR table allows for querying for all descendants of a hierarchical concept, and
+      the other way around. For example, drug ingredients and drug products, beneath them in the hierarchy,
+      are all descendants of a drug class ancestor. This table is entirely derived from the CONCEPT, CONCEPT_RELATIONSHIP,
+      and RELATIONSHIP tables.
     columns:
       - name: ancestor_concept_id
         description: The Concept Id for the higher-level concept that forms the ancestor inthe relationship.

--- a/models/omop/_models/concept_synonym.yml
+++ b/models/omop/_models/concept_synonym.yml
@@ -1,6 +1,8 @@
 models:
   - name: concept_synonym
-    description: The CONCEPT_SYNONYM table is used to store alternate names and descriptions for Concepts.
+    description: The CONCEPT_SYNONYM table captures alternative terms, synonyms, and translations of Concept
+      Name into various languages linked to specific concepts, providing users with a comprehensive view
+      of how Concepts may be expressed or referenced.
     columns:
       - name: concept_id
         description: ''

--- a/models/omop/_models/observation.yml
+++ b/models/omop/_models/observation.yml
@@ -66,7 +66,7 @@ models:
           into twocodes; one becomes the OBSERVATION_CONCEPT_ID and the other becomes theVALUE_AS_CONCEPT_ID.
           It is important when using the Observation table tokeep this possibility in mind and to examine
           the VALUE_AS_CONCEPT_IDfield for relevant information.
-        data_type: Integer
+        data_type: integer
         tests:
           - relationships:
               to: ref('concept')

--- a/models/omop/_models/relationship.yml
+++ b/models/omop/_models/relationship.yml
@@ -1,7 +1,10 @@
 models:
   - name: relationship
     description: The RELATIONSHIP table provides a reference list of all types of relationships that can
-      be used to associate any two concepts in the CONCEPT_RELATIONSHP table.
+      be used to associate any two Concepts in the CONCEPT_RELATIONSHIP table, the respective reverse
+      relationships, and their hierarchical characteristics. Note, that Concepts representing relationships
+      between the clinical facts, used for filling in the FACT_RELATIONSHIP table are stored in the CONCEPT
+      table and belong to the Relationship Domain.
     columns:
       - name: relationship_id
         description: The type of relationship captured by the relationship record.

--- a/models/omop/_models/visit_detail.yml
+++ b/models/omop/_models/visit_detail.yml
@@ -89,7 +89,7 @@ models:
         data_type: varchar(50)
       - name: visit_detail_source_concept_id
         description: ''
-        data_type: Integer
+        data_type: integer
         tests:
           - relationships:
               to: ref('concept')
@@ -98,7 +98,7 @@ models:
         description: Use this field to determine where the patient was admitted from. Thisconcept is part
           of the visit domain and can indicate if a patient wasadmitted to the hospital from a long-term
           care facility, for example.
-        data_type: Integer
+        data_type: integer
         tests:
           - dbt_utils.relationships_where:
               to: ref('concept')

--- a/models/staging/synthea/stg_synthea__claims.sql
+++ b/models/staging/synthea/stg_synthea__claims.sql
@@ -36,8 +36,8 @@ WITH cte_claims_lower AS (
         , diagnosis8 AS diagnosis_8
         , referringproviderid AS referring_provider_id
         , appointmentid AS encounter_id
-        , currentillnessdate AS current_illness_date
-        , servicedate AS service_datetime
+        , {{ timestamptz_to_naive("currentillnessdate") }} AS current_illness_date
+        , {{ timestamptz_to_naive("servicedate") }} AS service_datetime
         , supervisingproviderid AS supervising_provider_id
         , status1 AS claim_status_1
         , status2 AS claim_status_2
@@ -45,9 +45,9 @@ WITH cte_claims_lower AS (
         , outstanding1 AS outstanding_1
         , outstanding2 AS outstanding_2
         , outstandingp AS outstanding_patient
-        , lastbilleddate1 AS last_billed_date_1
-        , lastbilleddate2 AS last_billed_date_2
-        , lastbilleddatep AS last_billed_date_patient
+        , {{ timestamptz_to_naive("lastbilleddate1") }} AS last_billed_date_1
+        , {{ timestamptz_to_naive("lastbilleddate2") }} AS last_billed_date_2
+        , {{ timestamptz_to_naive("lastbilleddatep") }} AS last_billed_date_patient
         , healthcareclaimtypeid1 AS claim_type_id_1
         , healthcareclaimtypeid2 AS claim_type_id_2
     FROM cte_claims_lower

--- a/models/staging/synthea/stg_synthea__claims_transactions.sql
+++ b/models/staging/synthea/stg_synthea__claims_transactions.sql
@@ -20,8 +20,8 @@ WITH cte_claims_transactions_lower AS (
         , "type" AS transaction_type
         , {{ dbt.cast("amount", api.Column.translate_type("decimal")) }} AS transaction_amount
         , method AS transaction_method
-        , fromdate AS transaction_from_date
-        , todate AS transaction_to_date
+        , {{ timestamptz_to_naive("fromdate") }} AS transaction_from_date
+        , {{ timestamptz_to_naive("todate") }} AS transaction_to_date
         , placeofservice AS place_of_service
         , procedurecode AS procedure_code
         , modifier1 AS procedure_code_modifier_1

--- a/models/staging/synthea/stg_synthea__devices.sql
+++ b/models/staging/synthea/stg_synthea__devices.sql
@@ -13,10 +13,8 @@ WITH cte_devices_lower AS (
 , cte_devices_rename AS (
 
     SELECT
-        "start" AS device_start_datetime
-        , {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }} AS device_start_date
-        , "stop" AS device_stop_datetime
-        , {{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }} AS device_stop_date
+        {{ timestamptz_to_naive("\"start\"") }} AS device_start_datetime
+        , {{ timestamptz_to_naive("\"stop\"") }} AS device_stop_datetime
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS device_code
@@ -26,5 +24,21 @@ WITH cte_devices_lower AS (
 
 )
 
+, cte_devices_date_columns AS (
+
+    SELECT
+        device_start_datetime
+        , {{ dbt.cast("device_start_datetime", api.Column.translate_type("date")) }} AS device_start_date
+        , device_stop_datetime
+        , {{ dbt.cast("device_stop_datetime", api.Column.translate_type("date")) }} AS device_stop_date
+        , patient_id
+        , encounter_id
+        , device_code
+        , device_description
+        , udi
+    FROM cte_devices_rename
+
+)
+
 SELECT *
-FROM cte_devices_rename
+FROM cte_devices_date_columns

--- a/models/staging/synthea/stg_synthea__imaging_studies.sql
+++ b/models/staging/synthea/stg_synthea__imaging_studies.sql
@@ -14,7 +14,7 @@ WITH cte_imaging_studies_lower AS (
 
     SELECT
         id AS imaging_id
-        , "date" AS imaging_datetime
+        , {{ timestamptz_to_naive("\"date\"") }} AS imaging_datetime
         , patient AS patient_id
         , encounter AS encounter_id
         , series_uid

--- a/models/staging/synthea/stg_synthea__immunizations.sql
+++ b/models/staging/synthea/stg_synthea__immunizations.sql
@@ -13,7 +13,7 @@ WITH cte_immunizations_lower AS (
 , cte_immunizations_rename AS (
 
     SELECT
-        "date" AS immunization_date
+        {{ timestamptz_to_naive("\"date\"") }} AS immunization_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS immunization_code

--- a/models/staging/synthea/stg_synthea__medications.sql
+++ b/models/staging/synthea/stg_synthea__medications.sql
@@ -14,9 +14,7 @@ WITH cte_medications_lower AS (
 
     SELECT
         {{ timestamptz_to_naive("\"start\"") }} AS medication_start_datetime
-        , {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }} AS medication_start_date
         , {{ timestamptz_to_naive("\"stop\"") }} AS medication_stop_datetime
-        , {{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }} AS medication_stop_date
         , patient AS patient_id
         , payer AS payer_id
         , encounter AS encounter_id

--- a/models/staging/synthea/stg_synthea__medications.sql
+++ b/models/staging/synthea/stg_synthea__medications.sql
@@ -13,9 +13,9 @@ WITH cte_medications_lower AS (
 , cte_medications_rename AS (
 
     SELECT
-        "start" AS medication_start_datetime
+        {{ timestamptz_to_naive("\"start\"") }} AS medication_start_datetime
         , {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }} AS medication_start_date
-        , "stop" AS medication_stop_datetime
+        , {{ timestamptz_to_naive("\"stop\"") }} AS medication_stop_datetime
         , {{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }} AS medication_stop_date
         , patient AS patient_id
         , payer AS payer_id
@@ -32,5 +32,27 @@ WITH cte_medications_lower AS (
 
 )
 
+, cte_medications_date_columns AS (
+
+    SELECT
+        medication_start_datetime
+        , {{ dbt.cast("medication_start_datetime", api.Column.translate_type("date")) }} AS medication_start_date
+        , medication_stop_datetime
+        , {{ dbt.cast("medication_stop_datetime", api.Column.translate_type("date")) }} AS medication_stop_date
+        , patient_id
+        , payer_id
+        , encounter_id
+        , medication_code
+        , medication_description
+        , medication_base_cost
+        , medication_payer_coverage
+        , dispenses
+        , medication_total_cost
+        , medication_reason_code
+        , medication_reason_description
+    FROM cte_medications_rename
+
+)
+
 SELECT *
-FROM cte_medications_rename
+FROM cte_medications_date_columns

--- a/models/staging/synthea/stg_synthea__observations.sql
+++ b/models/staging/synthea/stg_synthea__observations.sql
@@ -13,7 +13,7 @@ WITH cte_observations_lower AS (
 , cte_observations_rename AS (
 
     SELECT
-        "date" AS observation_datetime
+        {{ timestamptz_to_naive("\"date\"") }} AS observation_datetime
         , {{ dbt.cast("\"date\"", api.Column.translate_type("date")) }} AS observation_date
         , patient AS patient_id
         , encounter AS encounter_id
@@ -27,5 +27,22 @@ WITH cte_observations_lower AS (
 
 )
 
+, cte_observation_date_columns AS (
+
+    SELECT
+        observation_datetime
+        , {{ dbt.cast("observation_datetime", api.Column.translate_type("date")) }} AS observation_date
+        , patient_id
+        , encounter_id
+        , observation_category
+        , observation_code
+        , observation_description
+        , observation_value
+        , observation_units
+        , observation_value_type
+    FROM cte_observations_rename
+
+)
+
 SELECT *
-FROM cte_observations_rename
+FROM cte_observation_date_columns

--- a/models/staging/synthea/stg_synthea__observations.sql
+++ b/models/staging/synthea/stg_synthea__observations.sql
@@ -14,7 +14,6 @@ WITH cte_observations_lower AS (
 
     SELECT
         {{ timestamptz_to_naive("\"date\"") }} AS observation_datetime
-        , {{ dbt.cast("\"date\"", api.Column.translate_type("date")) }} AS observation_date
         , patient AS patient_id
         , encounter AS encounter_id
         , category AS observation_category

--- a/models/staging/synthea/stg_synthea__payer_transitions.sql
+++ b/models/staging/synthea/stg_synthea__payer_transitions.sql
@@ -16,9 +16,7 @@ WITH cte_payer_transitions_lower AS (
         patient AS patient_id
         , memberid AS member_id
         , {{ timestamptz_to_naive("start_year") }} AS coverage_start_datetime
-        , {{ dbt.cast("start_year", api.Column.translate_type("date")) }} AS coverage_start_date
         , {{ timestamptz_to_naive("end_year") }} AS coverage_end_datetime
-        , {{ dbt.cast("end_year", api.Column.translate_type("date")) }} AS coverage_end_date
         , payer AS payer_id
         , secondary_payer AS secondary_payer_id
         , ownership AS plan_owner_relationship

--- a/models/staging/synthea/stg_synthea__payer_transitions.sql
+++ b/models/staging/synthea/stg_synthea__payer_transitions.sql
@@ -15,9 +15,9 @@ WITH cte_payer_transitions_lower AS (
     SELECT
         patient AS patient_id
         , memberid AS member_id
-        , start_year AS coverage_start_datetime
+        , {{ timestamptz_to_naive("start_year") }} AS coverage_start_datetime
         , {{ dbt.cast("start_year", api.Column.translate_type("date")) }} AS coverage_start_date
-        , end_year AS coverage_end_datetime
+        , {{ timestamptz_to_naive("end_year") }} AS coverage_end_datetime
         , {{ dbt.cast("end_year", api.Column.translate_type("date")) }} AS coverage_end_date
         , payer AS payer_id
         , secondary_payer AS secondary_payer_id
@@ -27,5 +27,22 @@ WITH cte_payer_transitions_lower AS (
 
 )
 
+, cte_payer_transitions_date_columns AS (
+
+    SELECT
+        patient_id
+        , member_id
+        , coverage_start_datetime
+        , {{ dbt.cast("coverage_start_datetime", api.Column.translate_type("date")) }} AS coverage_start_date
+        , coverage_end_datetime
+        , {{ dbt.cast("coverage_end_datetime", api.Column.translate_type("date")) }} AS coverage_end_date
+        , payer_id
+        , secondary_payer_id
+        , plan_owner_relationship
+        , plan_owner_name
+    FROM cte_payer_transitions_rename
+
+)
+
 SELECT *
-FROM cte_payer_transitions_rename
+FROM cte_payer_transitions_date_columns

--- a/models/staging/synthea/stg_synthea__procedures.sql
+++ b/models/staging/synthea/stg_synthea__procedures.sql
@@ -14,9 +14,7 @@ WITH cte_procedures_lower AS (
 
     SELECT
         {{ timestamptz_to_naive("\"start\"") }} AS procedure_start_datetime
-        , {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }} AS procedure_start_date
         , {{ timestamptz_to_naive("\"stop\"") }} AS procedure_stop_datetime
-        , {{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }} AS procedure_stop_date
         , patient AS patient_id
         , encounter AS encounter_id
         , code AS procedure_code

--- a/models/staging/synthea/stg_synthea__procedures.sql
+++ b/models/staging/synthea/stg_synthea__procedures.sql
@@ -13,9 +13,9 @@ WITH cte_procedures_lower AS (
 , cte_procedures_rename AS (
 
     SELECT
-        "start" AS procedure_start_datetime
+        {{ timestamptz_to_naive("\"start\"") }} AS procedure_start_datetime
         , {{ dbt.cast("\"start\"", api.Column.translate_type("date")) }} AS procedure_start_date
-        , "stop" AS procedure_stop_datetime
+        , {{ timestamptz_to_naive("\"stop\"") }} AS procedure_stop_datetime
         , {{ dbt.cast("\"stop\"", api.Column.translate_type("date")) }} AS procedure_stop_date
         , patient AS patient_id
         , encounter AS encounter_id
@@ -28,5 +28,23 @@ WITH cte_procedures_lower AS (
 
 )
 
+, cte_procedures_date_columns AS (
+
+    SELECT
+        procedure_start_datetime
+        , {{ dbt.cast("procedure_start_datetime", api.Column.translate_type("date")) }} AS procedure_start_date
+        , procedure_stop_datetime
+        , {{ dbt.cast("procedure_stop_datetime", api.Column.translate_type("date")) }} AS procedure_stop_date
+        , patient_id
+        , encounter_id
+        , procedure_code
+        , procedure_description
+        , procedure_base_cost
+        , procedure_reason_code
+        , procedure_reason_description
+    FROM cte_procedures_rename
+
+)
+
 SELECT *
-FROM cte_procedures_rename
+FROM cte_procedures_date_columns


### PR DESCRIPTION
Fixes #126 

- Adds 'timestamptz_to_naive' macro (created by katie).
- In staging models casts timestamptz columns to timestamp in UTC timezone.
- Where necessary adds an extra cte layer to staging models to ensure 'date' columns are based on the UTC timestamp.