### PR TITLE
Adjust unit thresh. and fix concept check

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -370,6 +370,21 @@ vars:
       vocabulary_reference: varchar
       vocabulary_version: varchar
       vocabulary_concept_id: integer
+    source_to_concept_map_seed: &stcm_columns
+      source_code: varchar
+      source_concept_id: integer
+      source_vocabulary_id: varchar
+      source_code_description: varchar
+      source_domain_id: varchar
+      source_concept_class_id: varchar
+      target_concept_id: integer
+      target_concept_name: varchar
+      target_vocabulary_id: varchar
+      target_domain_id: varchar
+      target_concept_class_id: varchar
+      valid_start_date: date
+      valid_end_date: date
+      invalid_reason: varchar
 
 models:
   synthea_omop_etl:
@@ -403,6 +418,13 @@ seeds:
       +schema: map_seeds
       +docs:
         node_color: '#69AED5'
+    stcm:
+      +enabled: true
+      +schema: vocab_seeds
+      +docs:
+        node_color: '#69AED5'
+      source_to_concept_map_seed:
+        +column_types: *stcm_columns
     vocabulary:
       +enabled: true
       +schema: vocab_seeds

--- a/models/intermediate/int__measurement_observations.sql
+++ b/models/intermediate/int__measurement_observations.sql
@@ -32,7 +32,7 @@ LEFT JOIN {{ ref ('int__source_to_standard_vocab_map') }} AS srcmap1
     ON
         o.observation_units = srcmap1.source_code
         AND srcmap1.target_vocabulary_id = 'UCUM'
-        AND srcmap1.source_vocabulary_id = 'UCUM'
+        AND srcmap1.source_vocabulary_id IN ('UCUM', 'Synthea units')
         AND srcmap1.target_standard_concept = 'S'
         AND srcmap1.target_invalid_reason IS null
 LEFT JOIN {{ ref ('int__source_to_standard_vocab_map') }} AS srcmap2

--- a/models/intermediate/int__source_to_standard_vocab_map.sql
+++ b/models/intermediate/int__source_to_standard_vocab_map.sql
@@ -30,3 +30,25 @@ INNER JOIN {{ ref( 'stg_vocabulary__concept') }} AS c1
     ON
         cr.concept_id_2 = c1.concept_id
         AND c1.invalid_reason IS null
+
+UNION ALL
+
+SELECT
+    source_code
+    , source_concept_id
+    , source_code_description
+    , source_vocabulary_id
+    , source_domain_id
+    , source_concept_class_id
+    , {{ dbt.cast("NULL", api.Column.translate_type("date")) }} AS source_valid_start_date
+    , {{ dbt.cast("NULL", api.Column.translate_type("date")) }} AS source_valid_end_date
+    , {{ dbt.cast("NULL", api.Column.translate_type("varchar")) }} AS source_invalid_reason
+    , target_concept_id
+    , target_concept_name
+    , target_vocabulary_id
+    , target_domain_id
+    , target_concept_class_id
+    , {{ dbt.cast("NULL", api.Column.translate_type("date")) }} AS target_invalid_reason
+    , 'S' AS target_standard_concept
+
+FROM {{ ref( 'stg_vocabulary__source_to_concept_map') }}

--- a/models/omop/_models/measurement.yml
+++ b/models/omop/_models/measurement.yml
@@ -163,7 +163,7 @@ models:
               from_condition: unit_concept_id <> 0
               to_condition: domain_id = 'Unit'
           - concept_record_completeness:
-              threshold: '20'
+              threshold: '7' # increased from default of 5 to 7 to account for unmappable units in Synthea
           - dbt_expectations.expect_column_to_exist
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list: "{{ get_type_variants(['bigint', 'integer']) }}"

--- a/models/omop/source_to_concept_map.sql
+++ b/models/omop/source_to_concept_map.sql
@@ -1,11 +1,11 @@
 SELECT
-    {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS source_code
-    , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS source_concept_id
-    , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS source_vocabulary_id
-    , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS source_code_description
-    , {{ dbt.cast("null", api.Column.translate_type("integer")) }} AS target_concept_id
-    , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS target_vocabulary_id
-    , {{ dbt.cast("null", api.Column.translate_type("date")) }} AS valid_start_date
-    , {{ dbt.cast("null", api.Column.translate_type("date")) }} AS valid_end_date
-    , {{ dbt.cast("null", api.Column.translate_type("varchar")) }} AS invalid_reason
-WHERE 1 = 0
+    source_code
+    , source_concept_id
+    , source_vocabulary_id
+    , source_code_description
+    , target_concept_id
+    , target_vocabulary_id
+    , valid_start_date
+    , valid_end_date
+    , invalid_reason
+FROM {{ ref('stg_vocabulary__source_to_concept_map') }}

--- a/models/staging/vocabulary/_vocabulary__model.yml
+++ b/models/staging/vocabulary/_vocabulary__model.yml
@@ -351,4 +351,3 @@ models:
       - name: valid_start_date
       - name: valid_end_date
       - name: invalid_reason
-      - name: target_concept_name

--- a/models/staging/vocabulary/_vocabulary__model.yml
+++ b/models/staging/vocabulary/_vocabulary__model.yml
@@ -339,3 +339,16 @@ models:
           - relationships:
               to: ref('concept')
               field: concept_id
+  
+  - name: stg_vocabulary__source_to_concept_map
+    columns:
+      - name: source_code
+      - name: source_concept_id
+      - name: source_vocabulary_id
+      - name: source_code_description
+      - name: target_concept_id
+      - name: target_vocabulary_id
+      - name: valid_start_date
+      - name: valid_end_date
+      - name: invalid_reason
+      - name: target_concept_name

--- a/models/staging/vocabulary/_vocabulary__sources.yml
+++ b/models/staging/vocabulary/_vocabulary__sources.yml
@@ -22,3 +22,4 @@ sources:
         identifier: "{% if var('seed_source', false) %}relationship_seed{% else %}relationship{% endif %}"
       - name: vocabulary
         identifier: "{% if var('seed_source', false) %}vocabulary_seed{% else %}vocabulary{% endif %}"
+      - name: source_to_concept_map_seed

--- a/models/staging/vocabulary/stg_vocabulary__source_to_concept_map.sql
+++ b/models/staging/vocabulary/stg_vocabulary__source_to_concept_map.sql
@@ -1,0 +1,14 @@
+{% set column_names = 
+    dbt_utils.get_filtered_columns_in_relation( source('vocabulary', 'source_to_concept_map_seed') ) 
+%}
+
+
+WITH cte_stcm_lower AS (
+
+    SELECT
+        {{ lowercase_columns(column_names) }}
+    FROM {{ source('vocabulary','source_to_concept_map_seed') }}
+)
+
+SELECT *
+FROM cte_stcm_lower

--- a/seeds/stcm/source_to_concept_map_seed.csv
+++ b/seeds/stcm/source_to_concept_map_seed.csv
@@ -1,0 +1,3 @@
+source_code,source_concept_id,source_vocabulary_id,source_code_description,source_domain_id,source_concept_class_id,target_concept_id,target_concept_name,target_vocabulary_id,target_domain_id,target_concept_class_id,valid_start_date,valid_end_date,invalid_reason
+"{score}",0,"Synthea units","{score}","Unit","Unit",44777566,"score","UCUM","Unit","Unit",1970-01-01,2099-12-31,
+"U/L",0,"Synthea units","U/L","Unit","Unit",8645,"unit per liter","UCUM","Unit","Unit",1970-01-01,2099-12-31,

--- a/tests/generic/concept_record_completeness.sql
+++ b/tests/generic/concept_record_completeness.sql
@@ -68,65 +68,66 @@ WITH validation AS (
         {% endif %}
 
     FROM {{ model }}
+    WHERE {{ column_name }} IS NOT NULL
     {% if model_name != 'dose_era' and (column_name == 'unit_concept_id' or column_name == 'unit_source_concept_id') %}
-    WHERE unit_source_value IS NOT NULL
+    OR unit_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'admitted_from_concept_id' %}
-    WHERE admitted_from_source_value IS NOT NULL
+    OR admitted_from_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'admitting_source_concept_id' %}
-    WHERE admitting_source_value IS NOT NULL
+    OR admitting_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'discharged_to_concept_id' %}
-    WHERE discharged_to_source_value IS NOT NULL
+    OR discharged_to_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'discharge_to_concept_id' %}
-    WHERE discharge_to_source_value IS NOT NULL
+    OR discharge_to_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'condition_status_concept_id' %}
-    WHERE condition_status_source_value IS NOT NULL
+    OR condition_status_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'route_concept_id' %}
-    WHERE route_source_value IS NOT NULL
+    OR route_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'modifier_concept_id' %}
-    WHERE modifier_source_value IS NOT NULL
+    OR modifier_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'qualifier_concept_id' %}
-    WHERE qualifier_source_value IS NOT NULL
+    OR qualifier_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'cause_concept_id' or column_name == 'cause_source_concept_id' %}
-    WHERE cause_source_value IS NOT NULL
+    OR cause_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'anatomic_site_concept_id' %}
-    WHERE anatomic_site_source_value IS NOT NULL
+    OR anatomic_site_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'disease_status_concept_id' %}
-    WHERE disease_status_source_value IS NOT NULL
+    OR disease_status_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'country_concept_id' %}
-    WHERE country_source_value IS NOT NULL
+    OR country_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'place_of_service_concept_id' %}
-    WHERE place_of_service_source_value IS NOT NULL
+    OR place_of_service_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'specialty_concept_id' or column_name == 'specialty_source_concept_id' %}
-    WHERE specialty_source_value IS NOT NULL
+    OR specialty_source_value IS NOT NULL
     {% endif %}
     {% if model_name == 'provider' and (column_name == 'gender_concept_id' or column_name == 'gender_source_concept_id') %}
-    WHERE gender_source_value IS NOT NULL
+    OR gender_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'payer_concept_id' or column_name == 'payer_source_concept_id' %}
-    WHERE payer_source_value IS NOT NULL
+    OR payer_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'plan_concept_id' or column_name == 'plan_source_concept_id' %}
-    WHERE plan_source_value IS NOT NULL
+    OR plan_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'sponsor_concept_id' or column_name == 'sponsor_source_concept_id' %}
-    WHERE sponsor_source_value IS NOT NULL
+    OR sponsor_source_value IS NOT NULL
     {% endif %}
     {% if column_name == 'stop_reason_concept_id' or column_name == 'stop_reason_source_concept_id' %}
-    WHERE stop_reason_source_value IS NOT NULL
+    OR stop_reason_source_value IS NOT NULL
     {% endif %}
 
 ),


### PR DESCRIPTION
- Adjust measurement unit concept ID completeness threshold to accommodate an unmappable concept in the source data
- Fix concept record completeness check (include concept ID 0 in all failures)
- Add source to concept map seed and related models to incorporate custom mappings for Synthea unit concepts